### PR TITLE
Use selenium-firefox docker image version 2.53.1

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -32,7 +32,7 @@ before_install:
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
-  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-firefox:2.53.1
+  - docker run -d -p 127.0.0.1:4444:4444 --net=host --shm-size=2g -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-firefox:2.53.1
 
 install:
   - moodle-plugin-ci install

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - export PATH="$(cd bin; pwd):$(cd vendor/bin; pwd):$PATH"
   - export TRAVIS_BUILD_DIR=$(cd ../moodle-local_travis; pwd)
   # Start Selenium Standalone with Chrome.
-  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-chrome:3
+  - docker run -d -p 127.0.0.1:4444:4444 --net=host --shm-size=2g -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-chrome:3
 
 install:
   - moodle-plugin-ci install
@@ -60,7 +60,6 @@ jobs:
     - stage: Tests
       addons: skip
       install:
-        - phpenv config-rm xdebug.ini
         - make init
       script:
         - make validate

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -70,7 +70,7 @@ before_install:
 # prefer to run Behat tests with Chrome profile (see Behat step details below),
 # use selenium/standalone-chrome:3 image instead. If you don't run Behat tests,
 # this step is not needed.
-  - docker run -d -p 127.0.0.1:4444:4444 --net=host -v /dev/shm:/dev/shm -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-firefox:2.53.1
+  - docker run -d -p 127.0.0.1:4444:4444 --net=host --shm-size=2g -v $HOME/build/moodle:$HOME/build/moodle selenium/standalone-firefox:2.53.1
 
 # This lists steps that are run for installation and setup.
 install:


### PR DESCRIPTION
Match selenium-firefox version used in https://github.com/moodlehq/moodle-docker (using version 3 will cause failure).

This also adds moodle dir mount to selenium container to allow running file upload
tests (blackboard-open-source/moodle-plugin-ci#110 (comment)).

Also remove PROFILE env var in .travis.yml to prevent assumption that
changing its value to firefox will work (it won't if version remains 3).

The change is realsed to new feature since 2.0.5 release and already reflected in Changelog.