### PR TITLE
Add --node-version parameter to install step.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,10 +23,14 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 - Updated version of `moodlehq/moodle-local_codechecker` to v2.9.6
 - Updated [.travis.dist.yml] to build Moodle 3.9
 - `moodle-plugin-ci install` installs Node.js (npm) using the version
-  specified in .nvmrc file. See
+  specified in .nvmrc file or `lts/carbon` if .nvmrc is missing (pre Moodle
+  3.5). It is also possible to override default version by providing
+  --node-version parameter or defining `NODE_VERSION` env variable. The value of
+  this parameter should be compatible with `nvm install` command,
+  e.g. `v8.9`, `8.9.0`, `lts/erbium`. See
   [#7](https://github.com/moodlehq/moodle-plugin-ci/issues/7)
 - ACTION REQUIRED: You may safely remove `nvm install <version>` and `nvm use
-  <version>` from .travis.yml for Moodle 3.5 and above, this is now a part of installation routine.
+  <version>` from .travis.yml, this is now a part of installation routine.
 
 ### Added
 - New help document: [CLI commands and options](CLI.md)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -813,7 +813,7 @@ Install everything required for CI testing
 
 ### Usage
 
-* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init]`
+* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init] [--node-version NODE-VERSION]`
 
 Install everything required for CI testing
 
@@ -944,6 +944,15 @@ Prevent PHPUnit and Behat initialization
 * Is value required: no
 * Is multiple: no
 * Default: `false`
+
+#### `--node-version`
+
+Node.js version to use for nvm install (this will override one defined in .nvmrc)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Default: `NULL`
 
 #### `--help|-h`
 

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -75,6 +75,7 @@ class InstallCommand extends Command
         $paths  = getenv('IGNORE_PATHS') !== false ? getenv('IGNORE_PATHS') : null;
         $names  = getenv('IGNORE_NAMES') !== false ? getenv('IGNORE_NAMES') : null;
         $extra  = getenv('EXTRA_PLUGINS_DIR') !== false ? getenv('EXTRA_PLUGINS_DIR') : null;
+        $node   = getenv('NODE_VERSION') !== false ? getenv('NODE_VERSION') : null;
 
         $this->setName('install')
             ->setDescription('Install everything required for CI testing')
@@ -91,7 +92,8 @@ class InstallCommand extends Command
             ->addOption('not-paths', null, InputOption::VALUE_REQUIRED, 'CSV of file paths to exclude', $paths)
             ->addOption('not-names', null, InputOption::VALUE_REQUIRED, 'CSV of file names to exclude', $names)
             ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra)
-            ->addOption('no-init', null, InputOption::VALUE_NONE, 'Prevent PHPUnit and Behat initialization');
+            ->addOption('no-init', null, InputOption::VALUE_NONE, 'Prevent PHPUnit and Behat initialization')
+            ->addOption('node-version', null, InputOption::VALUE_REQUIRED, 'Node.js version to use for nvm install (this will override one defined in .nvmrc)', $node);
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -161,6 +163,7 @@ class InstallCommand extends Command
         $factory->dumper     = $this->initializePluginConfigDumper($input);
         $factory->pluginsDir = $pluginsDir;
         $factory->noInit     = $input->getOption('no-init');
+        $factory->nodeVer    = $input->getOption('node-version');
         $factory->database   = $resolver->resolveDatabase(
             $input->getOption('db-type'),
             $input->getOption('db-name'),

--- a/src/Installer/InstallerFactory.php
+++ b/src/Installer/InstallerFactory.php
@@ -74,6 +74,11 @@ class InstallerFactory
     public $noInit;
 
     /**
+     * @var string
+     */
+    public $nodeVer;
+
+    /**
      * Given a big bag of install options, add installers to the collection.
      *
      * @param InstallerCollection $installers Installers will be added to this
@@ -82,7 +87,7 @@ class InstallerFactory
     {
         $installers->add(new MoodleInstaller($this->execute, $this->database, $this->moodle, new MoodleConfig(), $this->repo, $this->branch, $this->dataDir));
         $installers->add(new PluginInstaller($this->moodle, $this->plugin, $this->pluginsDir, $this->dumper));
-        $installers->add(new VendorInstaller($this->moodle, $this->plugin, $this->execute));
+        $installers->add(new VendorInstaller($this->moodle, $this->plugin, $this->execute, $this->nodeVer));
 
         if ($this->noInit) {
             return;


### PR DESCRIPTION
The option allows to override default Node.js version (which is picked
from .nvmrc) by providing --node-version parameter or defining
`NODE_VERSION` env variable. The value of this parameter should be
compatible with `nvm install` command, e.g. `v8.9`, `8.9.0`,
`lts/erbium`. Basically, assume it is added to .nvmrc and nvm should be
able to consume it while running `nvm install && nvm use`.