### PR TITLE
Add 310 to own tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,10 @@ script:
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache
-  - moodle-plugin-ci grunt || [ "$MOODLE_BRANCH" != 'master' -a "$MOODLE_BRANCH" != 'MOODLE_39_STABLE' ]
+  - moodle-plugin-ci grunt || [ \
+        "$MOODLE_BRANCH" != 'master' -a \
+        "$MOODLE_BRANCH" != 'MOODLE_310_STABLE' -a \
+        "$MOODLE_BRANCH" != 'MOODLE_39_STABLE' ]
   - moodle-plugin-ci phpdoc
   - moodle-plugin-ci phpunit --coverage-text
   - moodle-plugin-ci behat --profile default
@@ -62,6 +65,8 @@ jobs:
       script:
         - make validate
     - stage: Integration tests
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_310_STABLE
     - php: 7.4
       env: MOODLE_BRANCH=MOODLE_39_STABLE
     - php: 7.4


### PR DESCRIPTION
This just adds one more job (310) in the integration tests,
adding it to the list of correctly processed grunt branches
(together with 39 and master).

Once we get 35, 37, 38 out of support we'll be able to remove
that exceptional exit code handling (that I've not verified,
to be honest).

This fixes #29.