### PR TITLE
Prepare for 3.0.2 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,11 +52,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_ci",
-        "version": "1.0.5",
+        "version": "1.0.6",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_ci.git",
           "type": "git",
-          "reference": "3c8a4e7ed8dd14732ff21070dd8baab48c87fb0b"
+          "reference": "07ac69779414a3838ee9e95aebbd5068938e16f8"
         }
       }
     },
@@ -64,11 +64,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_moodlecheck",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_moodlecheck.git",
           "type": "git",
-          "reference": "79fe5956f9e9be906499c01dbc59695c2412643d"
+          "reference": "7e856a52fd8c9710da203873cf9674de4d1c2611"
         }
       }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3a5dbe720e542b16ce9bf24eedf209d",
+    "content-hash": "7c9944fe5c7563822cc23d5310a40bf8",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -183,11 +183,11 @@
         },
         {
             "name": "moodlehq/moodle-local_ci",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_ci.git",
-                "reference": "3c8a4e7ed8dd14732ff21070dd8baab48c87fb0b"
+                "reference": "07ac69779414a3838ee9e95aebbd5068938e16f8"
             },
             "type": "library"
         },
@@ -209,11 +209,11 @@
         },
         {
             "name": "moodlehq/moodle-local_moodlecheck",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_moodlecheck.git",
-                "reference": "79fe5956f9e9be906499c01dbc59695c2412643d"
+                "reference": "7e856a52fd8c9710da203873cf9674de4d1c2611"
             },
             "type": "library"
         },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,13 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ## [Unreleased]
 No unreleased changes.
 
+## [3.0.2] - 2020-09-11
+### Added
+- Skip HTML validation in mustache templates adding a `.mustachelintignore` standard ignores file to the plugin. Useful for templates containing specific syntax not being valid HTML (Ionic..).
+
+### Changed
+- Updated project dependencies to current [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) versions.
+
 ## [3.0.1] - 2020-09-04
 ### Changed
 - Updated [.travis.dist.yml] to use Postgresql 9.6 (Moodle 3.10 new requirement).
@@ -280,7 +287,8 @@ No unreleased changes.
 - `moodle-plugin-ci shifter` command.  Run YUI Shifter on plugin YUI modules.
 - `moodle-plugin-ci csslint` command.  Lints the CSS files in the plugin.
 
-[Unreleased]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.0...master
+[Unreleased]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.2...master
+[3.0.2]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.1...3.0.2
 [3.0.1]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/moodlehq/moodle-plugin-ci/compare/2.5.0...3.0.0
 [2.5.0]: https://github.com/moodlehq/moodle-plugin-ci/compare/2.4.0...2.5.0


### PR DESCRIPTION
Just bumping to current local_ci and local_moodlecheck that
come with some nice improvements:

- Support .mustachelintignore in mustache linting.
- Better valid API detection (online and external).
- Anonymous classes false positives.

Only the 1st one is worth being shared in the CHANGELOG, because it's something that devs can now go adding to their plugins, instead of using IGNOREFILES to completely ignore those files.

Note that this PR, if accepted must be applied WITHOUT commit merge ("rebase and merge", usually), because will be tagging it as 3.0.2.