### PR TITLE
Add GitHub actions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Latest Stable Version](https://poser.pugx.org/moodlehq/moodle-plugin-ci/v)](//packagist.org/packages/moodlehq/moodle-plugin-ci)
+![Moodle Plugin CI](https://github.com/moodlehq/moodle-plugin-ci/workflows/Moodle%20Plugin%20CI/badge.svg)
 [![Build Status](https://travis-ci.com/moodlehq/moodle-plugin-ci.svg?branch=master)](https://travis-ci.com/moodlehq/moodle-plugin-ci)
 [![Total Downloads](https://poser.pugx.org/moodlehq/moodle-plugin-ci/downloads)](//packagist.org/packages/moodlehq/moodle-plugin-ci)
 [![License](https://poser.pugx.org/moodlehq/moodle-plugin-ci/license)](//packagist.org/packages/moodlehq/moodle-plugin-ci)


### PR DESCRIPTION
This is how it looks rendered: https://github.com/kabalin/moodle-plugin-ci/tree/badge
