### PR TITLE
Add GitHub Action for release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Create Release
+
+on:
+  push:
+    tags: [ '*' ]
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP 7.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.3
+          ini-values: phar.readonly = false
+
+      - name: Build PHAR
+        run: |
+          make build/moodle-plugin-ci.phar
+          php build/moodle-plugin-ci.phar list
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token does not need to be defined, it is available by default.
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            Take a look at the [CHANGELOG](https://moodlehq.github.io/moodle-plugin-ci/CHANGELOG.html) for details about the release.
+            Please follow [3.0 Upgrade guide](https://moodlehq.github.io/moodle-plugin-ci/UPGRADE-3.0.html) when upgrading from 2.x.
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/moodle-plugin-ci.phar
+          asset_name: moodle-plugin-ci.phar
+          asset_content_type: application/zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,6 @@ jobs:
             "$MOODLE_BRANCH" != 'MOODLE_310_STABLE' -a \
             "$MOODLE_BRANCH" != 'MOODLE_39_STABLE' ]
         moodle-plugin-ci phpdoc
-        moodle-plugin-ci phpunit --coverage-text
+        moodle-plugin-ci phpunit
         moodle-plugin-ci behat --profile default
         moodle-plugin-ci behat --profile chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,19 +77,3 @@ jobs:
       env: MOODLE_BRANCH=MOODLE_35_STABLE
     - php: 7.0
       env: MOODLE_BRANCH=MOODLE_35_STABLE
-    - stage: Deploy
-      if: tag IS present
-      before_install: skip
-      install: skip
-      script: skip
-      before_deploy:
-        - make build/moodle-plugin-ci.phar
-        - php build/moodle-plugin-ci.phar list
-      deploy:
-        provider: releases
-        api_key: $GITHUB_TOKEN
-        file: build/moodle-plugin-ci.phar
-        skip_cleanup: true
-        on:
-          repo: moodlehq/moodle-plugin-ci
-          tags: true

--- a/docs/ReleaseNewVersion.md
+++ b/docs/ReleaseNewVersion.md
@@ -21,32 +21,29 @@ double CI build on Travis, also when merging PR, please **avoid merge commit**
 (use "Rebase and merge" option).
 
 Once all code and commits are in place and verified, you need to tag a
-release.
-
-__Note:__ Before sending the tag upstream, make sure that Travis is not running any
-builds, otherwise tag build might not get triggered. If this happenened, you
-need to remove tag and push it again when Travis is not busy.
-
-Tag `master` branch `HEAD` and push using commands:
+release. Tag `master` branch `HEAD` and push using commands:
 
 ```bash
 $ git tag -a 3.1.0 -m "Release version 3.1.0"
 $ git push origin 3.1.0
 ```
 
-(while it's also possible to use GitHub interface, we have decided not to do so, travis
-will, automatically, create the needed artifacts and perform the release)
+(while it's also possible to use GitHub interface, we have decided not to do
+so, GitHub release action will, automatically, create the needed artifacts and
+perform the release)
 
-When the tag is pushed, travis will trigger a tag build that contains Deploy stage.
-At this stage it should automatically create the `moodle-plugin-ci.phar` release artifact and add it
-to the latest release "assets" on GitHub. Verify it has worked correctly by
-navigating at [Releases](https://github.com/moodlehq/moodle-plugin-ci/releases).
+When the tag is pushed, GitHub release action will be triggered.  At this
+stage it should automatically create the `moodle-plugin-ci.phar` release
+artifact and add it to the latest release "assets" on GitHub. Verify it has
+worked correctly by navigating at
+[Releases](https://github.com/moodlehq/moodle-plugin-ci/releases).
 
-While in that page, optionally, you can edit the release and add any content to
-the description (we use to put some constant links to the changelog / upgrade docs,
-but anything important can be commented if needed to).
+While in that page, optionally, you can edit the release and add any content
+to the description (links to the changelog / upgrade docs are added
+automatically but anything important can be commented if needed to).
 
-If there is any problem with that automatic deployment, the artifact will need to be created manually. First build PHAR file manually:
+If there is any problem with that automatic deployment, the artifact will need
+to be created manually. First build PHAR file manually:
 
 ```bash
 $ make build/moodle-plugin-ci.phar


### PR DESCRIPTION
This patch is migrating automated release step from travis to GitHub Actions.

**To see how patch work:**
Test release 3.0.3.1: https://github.com/kabalin/moodle-plugin-ci/releases
Relevant release action: https://github.com/kabalin/moodle-plugin-ci/actions/runs/436555868

Following the merge:
- [ ] Remove $GITHUB_TOKEN in travis env settings for `moodle-plugin-ci`