### PR TITLE
Add GitHub Actions example and docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 [![Total Downloads](https://poser.pugx.org/moodlehq/moodle-plugin-ci/downloads)](//packagist.org/packages/moodlehq/moodle-plugin-ci)
 [![License](https://poser.pugx.org/moodlehq/moodle-plugin-ci/license)](//packagist.org/packages/moodlehq/moodle-plugin-ci)
 
-The goal of this project is to facilitate the running of tests and code analysis against a Moodle plugin in
-[Travis CI](https://travis-ci.com).  All of these tests and tools are run everytime a change is pushed to a GitHub
-branch or pull request.
+The goal of this project is to facilitate the running of tests and code
+analysis against a Moodle plugin in CI tools, such as [Travis
+CI](https://travis-ci.com) or [GitHub
+Actions](https://docs.github.com/en/actions).  All of these tests and tools
+are run everytime a change is pushed to a GitHub branch or pull request.
 
 * [Getting started](https://moodlehq.github.io/moodle-plugin-ci/)
 * [Help topics](https://moodlehq.github.io/moodle-plugin-ci/Help.html)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ### Fixed
 - `moodle-plugin-ci grunt` now only runs against the `yui/src` directory when configuring the YUI task.
   This resolves an issue where an "Unable to find local grunt" message was reported when code was structured in a legacy
-  format. See #46 for more details.
+  format. See [#46](https://github.com/moodlehq/moodle-plugin-ci/issues/46) for more details.
 
 ### Changed
 - `moodle-plugin-ci phpunit` when coverage report is included, phpdbg is called with ignore memory limits param
@@ -21,7 +21,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 
 ### Added
 - Detect existence of legacy php-webdriver, and use a different Firefox image when it is in use.
-- GitHub Actions use manual and example.
+- Add [manual](https://github.com/moodlehq/moodle-plugin-ci/blob/master/docs/index.md) and [example](https://github.com/moodlehq/moodle-plugin-ci/blob/master/docs/GHAFileExplained.md) on using GitHub Actions as CI tool.
 
 ## [3.0.3] - 2020-10-16
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,8 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 - Updated project dependencies to current [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) versions.
 
 ### Added
-- Detect existence of legacy php-webdriver, and use a different Firefox image when it is in use
+- Detect existence of legacy php-webdriver, and use a different Firefox image when it is in use.
+- GitHub Actions use manual and example.
 
 ## [3.0.3] - 2020-10-16
 ### Changed

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -8,8 +8,8 @@ Below is the
 file with comments added to explain what each section is doing. For additional
 information please refer to [workflow syntax reference](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).
 
-If you are familiar with Travis, this should be strightforward to understand
-the syntax, you may find this [migration
+If you are familiar with Travis, it should be straightforward to understand
+the new syntax, also you may find this [migration
 manual](https://docs.github.com/en/actions/learn-github-actions/migrating-from-travis-ci-to-github-actions)
 useful.
 
@@ -52,6 +52,9 @@ jobs:
     # build will be created. For example below 6 builds will be created in
     # total (7.2-pgsql, 7.2-mariadb, 7.3-pgsql, 7.3-mariadb, etc.). If we add
     # another branch, total number of builds will become 12.
+    # If you need to use PHP 7.0 and run phpunit coverage test, make sure you are
+    # using ubuntu-16.04 virtual environment in this case to have phpdbg or
+    # this version in the system.
     strategy:
       fail-fast: false
       matrix:

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -1,0 +1,165 @@
+---
+layout: page
+title: GitHub Actions CI workflow file explained
+---
+
+Below is the
+[gha.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/gha.dist.yml)
+file with comments added to explain what each section is doing. For additional
+information please refer to [workflow syntax reference](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).
+
+If you are familiar with Travis, this should be strightforward to understand
+the syntax, you may find this [migration
+manual](https://docs.github.com/en/actions/learn-github-actions/migrating-from-travis-ci-to-github-actions)
+useful.
+
+```yaml
+# Title of the workflow
+name: Moodle Plugin CI
+
+# Run this workflow every time a new commit pushed to your repository or PR
+# created.
+on: [push, pull_request]
+
+jobs:
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+  test:
+    # Virtual environment to use.
+    runs-on: ubuntu-18.04
+
+    # DB services you need for testing.
+    services:
+      postgres:
+        image: postgres:9.6
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    # Determines build matrix. This is a list of PHP versions, databases and
+    # branches to test our project against. For each combination a separate
+    # build will be created. For example below 6 builds will be created in
+    # total (7.2-pgsql, 7.2-mariadb, 7.3-pgsql, 7.3-mariadb, etc.). If we add
+    # another branch, total number of builds will become 12.
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.2', '7.3', '7.4']
+        moodle-branch: ['MOODLE_310_STABLE']
+        database: [pgsql, mariadb]
+
+    # There is an alterantive way allowing to define explicitly define which php, moodle-branch
+    # and database to use:
+    #
+    # matrix:
+    #   include:
+    #     - php: '7.4'
+    #       moodle-branch: 'MOODLE_310_STABLE'
+    #       database: pgsql
+    #     - php: '7.3'
+    #       moodle-branch: 'MOODLE_310_STABLE'
+    #       database: mariadb
+    #     - php: '7.2'
+    #       moodle-branch: 'MOODLE_39_STABLE'
+    #       database: pgsql
+
+    steps:
+      # Check out this repository code in ./plugin directory
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      # Install PHP of required version. For possible options see https://github.com/shivammathur/setup-php
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      # Install this project into a directory called "ci", updating PATH and
+      # locale.
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+
+      # Run the default install.
+      # Optionally, it is possible to specify a different Moodle repo to use
+      # (git://github.com/moodle/moodle.git is used by default) and define
+      # ignore directives or any other env vars for install step.
+      #
+      # env:
+      #   MOODLE_REPO=git://github.com/username/moodle.git
+      #   IGNORE_PATHS: 'ignore'
+      #   IGNORE_NAMES: 'ignore_name.php'
+      #   MUSTACHE_IGNORE_NAMES: 'broken.mustache'
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      # Steps that are run for the purpose of testing.  Any of these steps
+      # can be re-ordered or removed to your liking.  And of course, you can
+      # add any of your own custom steps.
+      - name: PHP Lint
+        if: ${{ always() }} # prevents CI run stopping if step failed.
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        continue-on-error: true
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome
+```

--- a/docs/Help.md
+++ b/docs/Help.md
@@ -18,6 +18,75 @@ changed.  Also a good place to look for new goodies.
 * [Generating code coverage](CodeCoverage.md): how to generate code coverage of your plugin.
 * [CLI commands and options](CLI.md): the available `moodle-plugin-ci` commands and their options.
 
+## Test steps quick start
+
+Below is short reference to steps you may find useful to optimise set of test steps you want to
+inclide in the CI scenario. For detailed information, see [CLI commands and options](CLI.md) manual.
+
+**moodle-plugin-ci phplint**
+
+This step lints your PHP files to check for syntax errors.
+
+**moodle-plugin-ci phpcpd**
+
+This step runs the PHP Copy/Paste Detector on your plugin. This helps to find
+code duplication.
+
+**moodle-plugin-ci phpmd**
+
+This step runs the PHP Mess Detector on your plugin. This helps to find
+potential problems with your code which can result in refactoring
+opportunities.
+
+**moodle-plugin-ci codechecker**
+
+This step runs the Moodle Code Checker to make sure that your
+plugin conforms to the Moodle coding standards.  It is highly recommended that
+you keep this step.  To fail on warnings use `--max-warnings 0`
+
+**moodle-plugin-ci phpdoc**
+
+This step runs Moodle PHPDoc checker on your plugin.
+
+**moodle-plugin-ci validate**
+
+This step runs some light validation on the plugin file structure
+and code.  Validation can be plugin specific.
+
+**moodle-plugin-ci savepoints**
+
+This step validates your plugin's upgrade steps.
+
+**moodle-plugin-ci mustache**
+
+This step validates the HTML and Javascript in your Mustache templates.
+
+**moodle-plugin-ci grunt**
+
+This step runs Grunt tasks on the plugin.  By default, it tries to run tasks
+relevant to your plugin and Moodle version, but you can run specific tasks by
+passing them as options, e.g.: `moodle-plugin-ci grunt -t task1 -t task2` To
+fail on eslint warnings use `--max-lint-warnings 0`
+
+**moodle-plugin-ci phpunit**
+
+This step runs the PHPUnit tests of your plugin.  If your plugin has
+PHPUnit tests, then it is highly recommended that you keep this step.
+
+**moodle-plugin-ci behat**
+
+This step runs the Behat tests of your plugin.  If your plugin has
+Behat tests, then it is highly recommended that you keep this step.
+There are few important options that you may want to use:
+- The auto rerun option allows you to rerun failures X number of times,
+  default is 2, EG usage: `--auto-rerun 3`
+- The dump option allows you to print the failure HTML to the console,
+  handy for debugging, e.g. usage: `--dump`
+- The suite option allows you to set the theme to use for behat test. If
+  not specified, the default theme is used, e.g. usage: `--suite boost`
+- The profile option allows you to set the browser driver to use,
+  default is Firefox. If you need Chrome, set `--profile chrome`.
+
 ## Upgrade guides
 
 * [Upgrading to Version 3](UPGRADE-3.0.md)

--- a/docs/Help.md
+++ b/docs/Help.md
@@ -10,7 +10,8 @@ changed.  Also a good place to look for new goodies.
 
 ## Help topics
 
-* [Travis CI file explained](TravisFileExplained.md): every line of the `.travis.yml` file explained.
+* [Travis CI file explained](TravisFileExplained.md): every line of the `.travis.dist.yml` file explained.
+* [GitHub Actions workflow file explained](GHAFileExplained.md): every line of the `gha.dist.yml` file explained.
 * [Add extra Moodle configs](AddExtraConfig.md): how to add extra configs to Moodle `config.php`.
 * [Add extra plugins](AddExtraPlugins.md): how to add plugin dependencies to Moodle.
 * [Ignoring files](IgnoringFiles.md): how to ignore files that might be causing failures.

--- a/docs/ReleaseNewVersion.md
+++ b/docs/ReleaseNewVersion.md
@@ -10,8 +10,10 @@ Prior to tagging a release, ensure the following have been updated:
 
 * The `CHANGELOG.md` needs to be up-to-date.  In addition, the _Unreleased_ section needs to be updated
   with the version being released.  Also update the _Unreleased_ link at the bottom with the new version number.
-* If this is a new major version, then the `.travis.dist.yml` and `doc/TravisFileExplained.md` need to be updated
-  to use the new major version.  Any other version will automatically be used.
+* If this is a new major version, then CI tool example files and its docs need
+  to be updated to use the new major version (e.g. for Travis CI make changes
+  in `.travis.dist.yml` and `doc/TravisFileExplained.md`). Any other version
+  will automatically be used.
 
 When all the changes above have been performed, push them straight upstream to
 `master` or create a standard PR to get them reviewed and incorporated

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,16 +37,18 @@ Please know older versions (1 and 2) are no longer getting new features and may 
 
 ## Getting started
 
-Follow these steps to get your Moodle plugin building in Travis CI.
+Follow steps to get your Moodle plugin building in CI tool of your choice.
 
-### Step 1
+### Travis CI
+
+#### Step 1
 
 Sign into [Travis CI](https://travis-ci.com) with your GitHub account. Once you’re signed in, and Travis CI will have
 synchronized your repositories from GitHub.  Go to your [profile](https://travis-ci.com/profile) page and enable Travis CI
 for the plugin you want to build.  Now whenever your plugin receives an update or gets a new pull request, Travis CI will
 run a build to make sure nothing broke.
 
-### Step 2
+#### Step 2
 
 Copy the [.travis.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/.travis.dist.yml) file into the
 root of your plugin and rename it to `.travis.yml`. Now might be a good time to review the `.travis.yml` contents and
@@ -54,13 +56,31 @@ remove anything that is not needed.  See this [help document](TravisFileExplaine
 contents of the this file. Once you have added the `.travis.yml` file, commit and push up to GitHub, to trigger a
 Travis CI build. Navigate back to [Travis CI](https://travis-ci.com) to see if your build passes or fails.
 
-### Step 3
+### GitHub Actions
 
-Congratulations, you are building on Travis CI!  Next steps on your continuous build journey include:
+#### Step 1
+
+Copy [gha.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/gha.dist.yml) file to `.github/workflows` directory
+in your project. You can give this file any name, e.g. `moodle-ci.yml` which we use in this document. Review the `moodle-ci.yml` contents and
+remove anything that is not needed.  See this [help document](GHAFileExplained.md) for an explanation about the
+contents of the this file. Once you have added the `.github/workflows/moodle-ci.yml` file, commit and push up to GitHub, to trigger a
+CI build.
+
+#### Step 2
+
+On GitHub, navigate to the main page of the repository. Under your repository
+name, click Actions tab and see your build status.  You may find this [Quick
+Start manual](https://docs.github.com/en/actions/quickstart#viewing-your-workflow-results)
+useful. Now whenever you push commits to your plugin repo or it gets a new
+pull request, GitHub will run a build to make sure nothing broke.
+
+### Getting more of CI
+
+Congratulations, you are running CI tests on your plugin!  Next steps on your continuous build journey include:
 
 * Reviewing the [help documentation](Help.md) to further improve and customize your build.
-* Resolve any build errors you may currently have.  Get to that ever rewarding Green Build status.
-* Show off your build status by [adding the badge to your plugin's README file](https://docs.travis-ci.com/user/status-images/).
+* Resolve any build errors you may currently have. Get to that ever rewarding Green Build status.
+* Show off your build status by adding the badge to your plugin's README file.
 * Write new tests to increase your code coverage.
 * Enjoy your favorite beverage because you no longer have to waste time manually testing your plugin!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,14 +3,21 @@ layout: page
 title: Introduction
 ---
 
-The goal of this project is to facilitate the running of tests and code analysis against a Moodle plugin in
-[Travis CI](https://travis-ci.com).  All of these tests and tools are run everytime a change is pushed to a GitHub
-branch or pull request.
+The goal of this project is to facilitate the running of tests and code
+analysis against a Moodle plugin in CI tool of your choice. All of these tests
+and tools are run everytime a change is pushed to a GitHub branch or pull
+request.
+
+We currently provide user manual how to use it with [Travis
+CI](https://travis-ci.com) and [GitHub
+Actions](https://docs.github.com/en/actions), if you are using
+`moodle-plugin-ci` with other CI services please do share your setup examples
+by creating a ticket.
 
 Why would you want to do this?  It saves you from having to remember to setup and run PHPUnit, Behat, code checker, etc
 every single time you make a change.  If you have enough test coverage, it also makes accepting pull requests painless
-because you can be more confident that the change wont break anything.  There are many more advantages to using a
-service like Travis CI, like being able to test your code against multiple databases, multiple PHP versions, etc.
+because you can be more confident that the change wont break anything.  There are many more advantages to use CI
+tools, like being able to test your code against multiple databases, multiple PHP versions, etc.
 
 This project supports the following testing frameworks and code analysis tools:
 * [PHPUnit](https://phpunit.de)
@@ -76,12 +83,13 @@ pull request, GitHub will run a build to make sure nothing broke.
 
 ### Getting more of CI
 
-Congratulations, you are running CI tests on your plugin!  Next steps on your continuous build journey include:
+Next steps on your continuous build journey may include:
 
 * Reviewing the [help documentation](Help.md) to further improve and customize your build.
 * Resolve any build errors you may currently have. Get to that ever rewarding Green Build status.
-* Show off your build status by adding the badge to your plugin's README file.
+* Show off your build status by adding the build status badge to your plugin's README file.
 * Write new tests to increase your code coverage.
+* Contribute to this repo if you have improvement idea or found an issue.
 * Enjoy your favorite beverage because you no longer have to waste time manually testing your plugin!
 
 ## Upgrading

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -1,0 +1,104 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+
+    services:
+      postgres:
+        image: postgres:9.6
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.2', '7.3', '7.4']
+        moodle-branch: ['MOODLE_310_STABLE']
+        database: [pgsql, mariadb]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome


### PR DESCRIPTION
Based on examples in #48 which were carefully reviewed and used in [moodle-mod_coursecertificate](https://github.com/moodleworkplace/moodle-mod_coursecertificate/blob/master/.github/workflows/moodle-ci.yml). Many thanks to @timhunt, @mackensen, @marinaglancy and others involved in discussion in related tickets.