### PR TITLE
GHA: nvm is available.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,11 +66,6 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v2
 
-    - name: Install node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '14.15.0'
-
     - name: Setup PHP ${{ matrix.php }}
       uses: shivammathur/setup-php@v2
       with:


### PR DESCRIPTION
By the look of it, `nvm` is included in ubuntu environments (e.g. https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md). Not sure how it was overlooked 🤷‍♂️ 