### PR TITLE
Enable all branches, both for push and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: Moodle Plugin CI
 
-on:
-  push:
-    branches: [ 'master' ]
-  pull_request:
-    branches: [ 'master' ]
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   selftest:


### PR DESCRIPTION
The most important it the push one, because anybody
contributing to mooodle-plugin-ci wont get their
dev/proposal branches tested. Only if they work on
master, they will.

About pull requests, this is less critical, as far as
master is out only current branch. But tomorrow we may
rename it, or create new upstream branches, so there
isn't anything wrong opening the doors to that now.