### PR TITLE
Run grunt task using npx.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-No unreleased changes.
+### Fixed
+- `moodle-plugin-ci grunt` should also be using `npx grunt` internally
 
 ## [3.0.5] - 2021-02-04
 ### Fixed

--- a/src/Command/GruntCommand.php
+++ b/src/Command/GruntCommand.php
@@ -69,7 +69,8 @@ class GruntCommand extends AbstractMoodleCommand
             }
 
             $builder = ProcessBuilder::create()
-                ->setPrefix('grunt');
+                ->setPrefix('npx')
+                ->add('grunt');
             if ($input->getOption('show-lint-warnings')) {
                 $builder->add('--show-lint-warnings');
             }


### PR DESCRIPTION
It looks like we relied on system installed one so far in grunt task (see https://github.com/kabalin/moodle-plugin-ci/runs/1845524756?check_suite_focus=true#step:7:53 modified run that included `whereis grunt`):
![Screenshot](https://user-images.githubusercontent.com/329780/107124145-ebc87500-6899-11eb-934b-c3cd53b8d6c0.png)

Something I forgot to check when #51 was landed 😞 Only noticed as I tested the latest `moodle-plugin-ci` within `moodlehq/moodle-php-apache:7.2` based container in Gitlab and it failed with `sh: 1: grunt: not found`.
