### PR TITLE
Test against multiple Moodle branches by default

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -13,17 +13,29 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.npm
 
-php:
- - 7.2
- - 7.3
- - 7.4
-
-env:
- global:
-  - MOODLE_BRANCH=MOODLE_39_STABLE
- matrix:
-  - DB=pgsql
-  - DB=mysqli
+jobs:
+ include:
+  # Moodle 3.5
+  #- php: 7.0 # 7.0-7.2
+  #  env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
+  # Moodle 3.8
+  #- php: 7.1 # 7.1-7.4
+  #  env: MOODLE_BRANCH=MOODLE_38_STABLE DB=mysqli
+  # Moodle 3.9
+  - php: 7.2 # 7.2-7.4
+    env: MOODLE_BRANCH=MOODLE_39_STABLE DB=mysqli
+  # Moodle 3.9, PostgreSQL
+  - php: 7.3 # 7.2-7.4
+    env: MOODLE_BRANCH=MOODLE_39_STABLE DB=pgsql
+  # Moodle 3.10
+  - php: 7.4 # 7.2-7.4
+    env: MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
+  # Moodle 3.11
+  #- php: 7.4 # 7.2-7.4
+  #  env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
+  # Moodle Master
+  #- php: 7.4 # 7.2-7.4
+  #  env: MOODLE_BRANCH=master DB=mysqli
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-No unreleased changes.
+### Changed
+- Test against multiple branches of Moodle by default.
 
 ## [3.0.6] - 2021-02-08
 ### Fixed

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -47,35 +47,35 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
 
-    # Determines build matrix. This is a list of PHP versions, databases and
-    # branches to test our project against. For each combination a separate
-    # build will be created. For example below 6 builds will be created in
-    # total (7.2-pgsql, 7.2-mariadb, 7.3-pgsql, 7.3-mariadb, etc.). If we add
-    # another branch, total number of builds will become 12.
+    # The settings for each build to test against, including the version of PHP,
+    # Moodle branch, and database.
     # If you need to use PHP 7.0 and run phpunit coverage test, make sure you are
     # using ubuntu-16.04 virtual environment in this case to have phpdbg or
     # this version in the system.
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4']
-        moodle-branch: ['MOODLE_310_STABLE']
-        database: [pgsql, mariadb]
+        include:
+          # Moodle 3.9
+          - php: '7.2' # 7.2-7.4
+            moodle-branch: 'MOODLE_39_STABLE'
+            database: mariadb
+          # Moodle 3.9, PostgreSQL
+          - php: '7.3' # 7.2-7.4
+            moodle-branch: 'MOODLE_39_STABLE'
+            database: pgsql
+          # Moodle 3.10
+          - php: '7.4' # 7.2-7.4
+            moodle-branch: 'MOODLE_310_STABLE'
+            database: mariadb
 
-    # There is an alterantive way allowing to define explicitly define which php, moodle-branch
-    # and database to use:
+    # There is an alterantive way which will test against every combination of
+    # the specified PHP versions, Moodle branches, and databases:
     #
     # matrix:
-    #   include:
-    #     - php: '7.4'
-    #       moodle-branch: 'MOODLE_310_STABLE'
-    #       database: pgsql
-    #     - php: '7.3'
-    #       moodle-branch: 'MOODLE_310_STABLE'
-    #       database: mariadb
-    #     - php: '7.2'
-    #       moodle-branch: 'MOODLE_39_STABLE'
-    #       database: pgsql
+    #   php: ['7.2', '7.3', '7.4']
+    #   moodle-branch: ['MOODLE_39_STABLE']
+    #   database: [pgsql, mariadb]
 
     steps:
       # Check out this repository code in ./plugin directory

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -27,47 +27,40 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.npm
 
-# Determines which versions of PHP to test our project against.  Each version
-# listed here will create a separate build and run the tests against that
-# version of PHP.
-php:
- - 7.2
- - 7.3
- - 7.4
-
-# This section sets up the environment variables for the build.
-env:
- global:
-# This line determines which version branch of Moodle to test against.
-  - MOODLE_BRANCH=MOODLE_39_STABLE
-# This matrix is used for testing against multiple databases.  So for
-# each version of PHP being tested, one build will be created for each
-# database listed here.  EG: for PHP 7.3, one build will be created
-# using PHP 7.3 and pgsql.  In addition, another build will be created
-# using PHP 7.3 and mysqli.
- matrix:
-  - DB=pgsql
-  - DB=mysqli
-
+# The settings for each build to test against, including the version of PHP,
+# and the environment variables, which determine the Moodle branch and database.
+jobs:
+ include:
+  # Moodle 3.9
+  - php: 7.2 # 7.2-7.4
+    env: MOODLE_BRANCH=MOODLE_39_STABLE DB=mysqli
+  # Moodle 3.9, PostgreSQL
+  - php: 7.3 # 7.2-7.4
+    env: MOODLE_BRANCH=MOODLE_39_STABLE DB=pgsql
+  # Moodle 3.10
+  - php: 7.4 # 7.2-7.4
+    env: MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
 # Optionally, it is possible to specify a different Moodle repo to use
 # (git://github.com/moodle/moodle.git is used by default):
 # - MOODLE_REPO=git://github.com/username/moodle.git
-
-# Also, note that, for multi-branch scenarios, where the same plugin
-# codebase needs to be tested against multiple branches of Moodle,
-# it is possible to remove the `php`, `env/global`, and `matrix`
-# sections above and just create a `jobs` section explicitly defining
-# which `php`, `MOODLE_BRANCH` and `DB` to use, for example:
-#
-# jobs:
-#   include:
-#     - php: 7.3
-#       env: MOODLE_BRANCH=MOODLE_39_STABLE    DB=pgsql
-#     - php: 7.3
-#       env: MOODLE_BRANCH=MOODLE_39_STABLE    DB=mysqli
-#     ....
-# Note: this also enables to add specific env variables (NODE_VERSION,
+# Note: It is also possible to add specific env variables (NODE_VERSION,
 # EXTRA_PLUGINS...) per job, if you don't want to do it globally.
+
+# Also, note that, if the plugin codebase only needs to be tested against
+# one branch of Moodle, it is possible to remove the `jobs` section,
+# and add the following sections, which will test against one Moodle branch,
+# with every combination of the specified PHP versions and the databases.
+#
+# php:
+#  - 7.2
+#  - 7.3
+#  - 7.4
+# env:
+#  global:
+#   - MOODLE_BRANCH=MOODLE_39_STABLE
+#  matrix:
+#   - DB=pgsql
+#   - DB=mysqli
 
 # This lists steps that are run before the installation step.
 before_install:

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -27,9 +27,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4']
-        moodle-branch: ['MOODLE_310_STABLE']
-        database: [pgsql, mariadb]
+        include:
+          # Moodle 3.5
+          #- php: '7.1' # 7.0-7.2
+          #  moodle-branch: 'MOODLE_35_STABLE'
+          #  database: mariadb
+          # Moodle 3.8
+          #- php: '7.1' # 7.1-7.4
+          #  moodle-branch: 'MOODLE_38_STABLE'
+          #  database: mariadb
+          # Moodle 3.9
+          - php: '7.2' # 7.2-7.4
+            moodle-branch: 'MOODLE_39_STABLE'
+            database: mariadb
+          # Moodle 3.9, PostgreSQL
+          - php: '7.3' # 7.2-7.4
+            moodle-branch: 'MOODLE_39_STABLE'
+            database: pgsql
+          # Moodle 3.10
+          - php: '7.4' # 7.2-7.4
+            moodle-branch: 'MOODLE_310_STABLE'
+            database: mariadb
+          # Moodle 3.11
+          #- php: '7.4' # 7.2-7.4
+          #  moodle-branch: 'MOODLE_311_STABLE'
+          #  database: mariadb
+          # Moodle Master
+          #- php: '7.4' # 7.2-7.4
+          #  moodle-branch: 'master'
+          #  database: mariadb
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
This replaces #66.

In response to feedback:
- Moodle versions that are no longer supported at all have been removed entirely, and only current stable Moodle versions are enabled by default, others are commented out.
- The NODE_VERSION env variable is removed.

Also, corresponding changes are made to the new GitHub Actions script, and the docs explaining the Travis and GitHub Actions scripts.

I thought there were enough changes to warrant a new pull request.