### PR TITLE
Bump php-cs-fixer to v2.19.0

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -20,7 +20,7 @@ Copyright (c) 2018 Blackboard Inc. (http://www.blackboard.com)
 License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 EOF;
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony'                              => true,
@@ -28,26 +28,36 @@ return PhpCsFixer\Config::create()
         'array_syntax'                          => ['syntax' => 'short'],
         'combine_consecutive_unsets'            => true,
         'combine_consecutive_issets'            => true,
-        'general_phpdoc_annotation_remove'      => ['expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'],
+        'general_phpdoc_annotation_remove'      => ['annotations' => [
+                                                       'expectedException',
+                                                       'expectedExceptionMessage',
+                                                       'expectedExceptionMessageRegExp',
+                                                   ]],
         'header_comment'                        => ['header' => $header],
         'heredoc_to_nowdoc'                     => true,
-        'no_extra_consecutive_blank_lines'      => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'],
-        'no_short_echo_tag'                     => true,
+        'no_extra_blank_lines'                  => ['tokens' => [
+                                                       'break', 'continue', 'extra', 'return',
+                                                       'throw', 'use', 'parenthesis_brace_block',
+                                                       'square_brace_block', 'curly_brace_block',
+                                                   ]],
+        'echo_tag_syntax'                       => true,
         'no_unreachable_default_argument_value' => true,
         'no_useless_else'                       => true,
         'no_useless_return'                     => true,
         'ordered_imports'                       => true,
         'php_unit_strict'                       => true,
         'phpdoc_add_missing_param_annotation'   => true,
+        'no_superfluous_phpdoc_tags'            => false,
         'phpdoc_order'                          => true,
         'semicolon_after_instruction'           => true,
         'strict_comparison'                     => true,
         'strict_param'                          => true,
-        'binary_operator_spaces'                => ['align_equals' => true, 'align_double_arrow' => true],
+        'binary_operator_spaces'                => ['operators' => ['=' => 'align', '=>' => 'align']],
         'align_multiline_comment'               => true,
         'yoda_style'                            => false,
         'compact_nullable_typehint'             => true,
         'native_function_invocation'            => false,
+        'native_constant_invocation'            => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 
 # Update download URL from https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases
 build/php-cs-fixer.phar:
-	curl -LSs https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.14.2/php-cs-fixer.phar -o build/php-cs-fixer.phar
+	curl -LSs https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.19.0/php-cs-fixer.phar -o build/php-cs-fixer.phar
 
 # Update download URL from https://github.com/vimeo/psalm/releases
 build/psalm.phar:

--- a/bin/moodle-plugin-ci
+++ b/bin/moodle-plugin-ci
@@ -42,7 +42,7 @@ if (file_exists(__DIR__.'/../../../autoload.php')) {
     require_once __DIR__.'/../vendor/autoload.php';
 } else {
     fwrite(STDERR, 'Failed to find Composer\'s autoload file. You might need to run Composer\'s install on this project'.PHP_EOL);
-    die(1);
+    exit(1);
 }
 
 define('MOODLE_PLUGIN_CI_BOXED', '@is_boxed@');

--- a/tests/Command/SavePointsCommandTest.php
+++ b/tests/Command/SavePointsCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class SavePointsCommandTest extends MoodleTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
     }


### PR DESCRIPTION
That version supports PHP8 and is the last one
before jumping to v3 that comes with huge changes.

This will help in the progress towards PHP8 support happening @ #94 