### PR TITLE
Update project dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,11 +58,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_moodlecheck",
-        "version": "1.0.6",
+        "version": "1.0.7",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_moodlecheck.git",
           "type": "git",
-          "reference": "5edcc27e76081de295a2107681bb88232a828a99"
+          "reference": "v1.0.7"
         }
       }
     }
@@ -71,7 +71,7 @@
     "php": ">=7.0.8",
     "moodlehq/moodle-local_codechecker": "^3.0.1",
     "moodlehq/moodle-local_ci": "^1.0.9",
-    "moodlehq/moodle-local_moodlecheck": "^1.0.6",
+    "moodlehq/moodle-local_moodlecheck": "^1.0.7",
     "sebastian/phpcpd": "^3.0",
     "phpmd/phpmd": "^2.2",
     "symfony/dotenv": "^3.4",
@@ -83,7 +83,7 @@
     "php-parallel-lint/php-parallel-lint": "^1.2.0",
     "php-parallel-lint/php-console-highlighter": "^0.5",
     "psr/log": "^1.0",
-    "nikic/php-parser": "^3.0",
+    "nikic/php-parser": "^4.0",
     "stecman/symfony-console-completion": "^0.7.0",
     "marcj/topsort": "^1.0",
     "padraic/phar-updater": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b475bf8c5922f67a268e2806be58c9c",
+    "content-hash": "e20bf037bd9aea7b82ce95e83028aea9",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -84,16 +84,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.6",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f27e06cd9675801df441b3656569b328e04aa37c"
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f27e06cd9675801df441b3656569b328e04aa37c",
-                "reference": "f27e06cd9675801df441b3656569b328e04aa37c",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
                 "shasum": ""
             },
             "require": {
@@ -128,7 +128,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.6"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
             },
             "funding": [
                 {
@@ -144,7 +144,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-25T17:01:18+00:00"
+            "time": "2021-05-05T19:37:51+00:00"
         },
         {
             "name": "marcj/topsort",
@@ -219,34 +219,35 @@
         },
         {
             "name": "moodlehq/moodle-local_moodlecheck",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_moodlecheck.git",
-                "reference": "5edcc27e76081de295a2107681bb88232a828a99"
+                "reference": "v1.0.7"
             },
             "type": "library"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.1.5",
+            "version": "v4.10.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce"
+                "reference": "4432ba399e47c66624bc73c8c0f811e5c109576f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
-                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4432ba399e47c66624bc73c8c0f811e5c109576f",
+                "reference": "4432ba399e47c66624bc73c8c0f811e5c109576f",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.5"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0|~5.0"
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -254,7 +255,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.9-dev"
                 }
             },
             "autoload": {
@@ -278,9 +279,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v3.1.5"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.5"
             },
-            "time": "2018-02-28T20:30:58+00:00"
+            "time": "2021-05-03T19:11:20+00:00"
         },
         {
             "name": "padraic/humbug_get_contents",
@@ -630,22 +631,22 @@
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.9.1",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "ce10831d4ddc2686c1348a98069771dd314534a8"
+                "reference": "bd5ef43d1dcaf7272605027c959c1c5ff3761f7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/ce10831d4ddc2686c1348a98069771dd314534a8",
-                "reference": "ce10831d4ddc2686c1348a98069771dd314534a8",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/bd5ef43d1dcaf7272605027c959c1c5ff3761f7a",
+                "reference": "bd5ef43d1dcaf7272605027c959c1c5ff3761f7a",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.0",
+                "composer/xdebug-handler": "^1.0 || ^2.0",
                 "ext-xml": "*",
-                "pdepend/pdepend": "^2.7.1",
+                "pdepend/pdepend": "^2.9.1",
                 "php": ">=5.3.9"
             },
             "require-dev": {
@@ -653,7 +654,7 @@
                 "ext-json": "*",
                 "ext-simplexml": "*",
                 "gregwar/rst": "^1.0",
-                "mikey179/vfsstream": "^1.6.4",
+                "mikey179/vfsstream": "^1.6.8",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.27",
                 "squizlabs/php_codesniffer": "^2.0"
             },
@@ -701,7 +702,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/phpmd",
                 "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.9.1"
+                "source": "https://github.com/phpmd/phpmd/tree/2.10.1"
             },
             "funding": [
                 {
@@ -709,7 +710,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-23T22:06:32+00:00"
+            "time": "2021-05-11T17:16:16+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -819,16 +820,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -852,7 +853,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -863,9 +864,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.3"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2020-03-23T09:12:05+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sebastian/finder-facade",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -79,4 +79,11 @@
       <code>$input-&gt;getOption('moodle')</code>
     </PossiblyInvalidArgument>
   </file>
+  <file src="src/Parser/StatementFilter.php">
+    <PossiblyInvalidCast occurrences="3">
+      <code>$assign-&gt;var-&gt;name</code>
+      <code>$assign-&gt;var-&gt;name</code>
+      <code>$var-&gt;name</code>
+    </PossiblyInvalidCast>
+  </file>
 </files>

--- a/src/Bridge/MessDetectorRenderer.php
+++ b/src/Bridge/MessDetectorRenderer.php
@@ -57,7 +57,9 @@ class MessDetectorRenderer extends AbstractRenderer
         $groupByFile = [];
         /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
-            $groupByFile[$violation->getFileName()][] = $violation;
+            if ($filename = $violation->getFileName()) {
+                $groupByFile[$filename][] = $violation;
+            }
         }
 
         /** @var ProcessingError $error */

--- a/src/Command/MessDetectorCommand.php
+++ b/src/Command/MessDetectorCommand.php
@@ -14,6 +14,7 @@ namespace MoodlePluginCI\Command;
 
 use MoodlePluginCI\Bridge\MessDetectorRenderer;
 use PHPMD\PHPMD;
+use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 use PHPMD\Writer\StreamWriter;
 use Symfony\Component\Console\Input\InputInterface;
@@ -52,7 +53,7 @@ class MessDetectorCommand extends AbstractMoodleCommand
         $ruleSetFactory->setMinimumPriority(5);
 
         $messDetector = new PHPMD();
-        $messDetector->processFiles(implode(',', $files), $rules, [$renderer], $ruleSetFactory);
+        $messDetector->processFiles(implode(',', $files), $rules, [$renderer], $ruleSetFactory, new Report());
 
         return 0;
     }

--- a/src/PluginValidate/Finder/FunctionFinder.php
+++ b/src/PluginValidate/Finder/FunctionFinder.php
@@ -27,7 +27,7 @@ class FunctionFinder extends AbstractParserFinder
         $statements = $this->parser->parseFile($file);
 
         foreach ($this->filter->filterFunctions($statements) as $function) {
-            $fileTokens->compare($function->name);
+            $fileTokens->compare((string) $function->name);
         }
     }
 }


### PR DESCRIPTION
Most noticeble one being local_moodlecheck v1.0.7 that
comes with PHP8 specific fixes.

Also updated nikic/php-parser to newer version, able
to run with any >= 7.0 PHP version (8.0 included) and
parse every PHP version (5.x to 8.0).

Changes to the php-parser required some changes in code:

- Look for assignments inside extra Expression element.
- Add 3 psalm cases to baseline, about some casts (the
  objects have the _toString() method, but psalm isn't
  aware).

(details @ https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-4.0.md)

Finally, some changes because of phpmd bump were also required.