### PR TITLE
Move local_ci dependency to tagged one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_ci",
-        "version": "1.0.9",
+        "version": "1.0.10",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_ci.git",
           "type": "git",
-          "reference": "7a3cef3ce127ef8037765e79518661f03ae1396f"
+          "reference": "v1.0.10"
         }
       }
     },
@@ -70,7 +70,7 @@
   "require": {
     "php": ">=7.0.8",
     "moodlehq/moodle-local_codechecker": "^3.0.1",
-    "moodlehq/moodle-local_ci": "^1.0.9",
+    "moodlehq/moodle-local_ci": "^1.0.10",
     "moodlehq/moodle-local_moodlecheck": "^1.0.7",
     "sebastian/phpcpd": "^3.0",
     "phpmd/phpmd": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e20bf037bd9aea7b82ce95e83028aea9",
+    "content-hash": "904217cbf0165ba329724335bde3432b",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -199,11 +199,11 @@
         },
         {
             "name": "moodlehq/moodle-local_ci",
-            "version": "1.0.9",
+            "version": "1.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_ci.git",
-                "reference": "7a3cef3ce127ef8037765e79518661f03ae1396f"
+                "reference": "v1.0.10"
             },
             "type": "library"
         },


### PR DESCRIPTION
No much to say, this could have happened in the previous PR, when we also switched to tagged `local_moodlecheck`, but there were other impeding changes there.

So doing it here, now local_ci has tags too, so using them.

Ciao :-)

