### PR TITLE
Prepare for 3.1.0 release

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -14,18 +14,20 @@ cache:
     - $HOME/.npm
 
 php:
- - 7.2
  - 7.3
  - 7.4
+ - 8.0
 
 env:
  global:
-  - MOODLE_BRANCH=MOODLE_39_STABLE
+  - MOODLE_BRANCH=MOODLE_311_STABLE
  matrix:
   - DB=pgsql
   - DB=mysqli
 
 before_install:
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} -gt 7 ]]; then pecl install xmlrpc-beta; fi
+  - echo 'max_input_vars=5000' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,21 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ## [Unreleased]
 No unreleased changes.
 
+## [3.1.0] - 2021-05-14
+### Added
+- Support for PHP 8.0 jobs.
+- ACTION REQUIRED: Small modifications are required to both Travis and GHA integrations,
+  only if adding PHP 8 jobs. These changes include 1) Setting up the `max_input_vars=5000`
+  PHP configuration setting, for all runs, and 2) Enabling the `xmlrpc-beta` extension
+  if the plugin requires xmlrpc services, only for PHP 8 runs. See
+  [gha.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/gha.dist.yml) and
+  [.travis.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/.travis.dist.yml) for more information.
+
+### Changed
+- Updated various internal dependencies and tools.
+- Moved [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and
+  [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) dependencies to use tagged references instead of commit ones.
+
 ## [3.0.8] - 2021-04-23
 ### Changed
 - Updated project dependencies to current [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) versions.
@@ -336,7 +351,8 @@ No unreleased changes.
 - `moodle-plugin-ci shifter` command.  Run YUI Shifter on plugin YUI modules.
 - `moodle-plugin-ci csslint` command.  Lints the CSS files in the plugin.
 
-[Unreleased]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.8...master
+[Unreleased]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.1.0...master
+[3.1.0]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.8...3.1.0
 [3.0.8]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.7...3.0.8
 [3.0.7]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.6...3.0.7
 [3.0.6]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.0.5...3.0.6

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -50,7 +50,7 @@ jobs:
     # Determines build matrix. This is a list of PHP versions, databases and
     # branches to test our project against. For each combination a separate
     # build will be created. For example below 6 builds will be created in
-    # total (7.2-pgsql, 7.2-mariadb, 7.3-pgsql, 7.3-mariadb, etc.). If we add
+    # total (7.3-pgsql, 7.3-mariadb, 7.4-pgsql, 7.4-mariadb, etc.). If we add
     # another branch, total number of builds will become 12.
     # If you need to use PHP 7.0 and run phpunit coverage test, make sure you are
     # using ubuntu-16.04 virtual environment in this case to have phpdbg or
@@ -58,22 +58,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4']
-        moodle-branch: ['MOODLE_310_STABLE']
+        php: ['7.3', '7.4', '8.0']
+        moodle-branch: ['MOODLE_311_STABLE']
         database: [pgsql, mariadb]
 
-    # There is an alterantive way allowing to define explicitly define which php, moodle-branch
+    # There is an alternative way allowing to define explicitly define which php, moodle-branch
     # and database to use:
     #
     # matrix:
     #   include:
+    #     - php: '8.0'
+    #       moodle-branch: 'MOODLE_311_STABLE'
+    #       database: pgsql
+    # Optional line: Only needed if going to run php8 jobs and the plugin
+    # needs xmlrpc services or other special extensions.
+    #       extensions: xmlrpc-beta
     #     - php: '7.4'
     #       moodle-branch: 'MOODLE_310_STABLE'
-    #       database: pgsql
-    #     - php: '7.3'
-    #       moodle-branch: 'MOODLE_310_STABLE'
     #       database: mariadb
-    #     - php: '7.2'
+    #     - php: '7.3'
     #       moodle-branch: 'MOODLE_39_STABLE'
     #       database: pgsql
 
@@ -89,6 +92,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
           coverage: none
 
       # Install this project into a directory called "ci", updating PATH and

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -31,15 +31,15 @@ cache:
 # listed here will create a separate build and run the tests against that
 # version of PHP.
 php:
- - 7.2
  - 7.3
  - 7.4
+ - 8.0
 
 # This section sets up the environment variables for the build.
 env:
  global:
 # This line determines which version branch of Moodle to test against.
-  - MOODLE_BRANCH=MOODLE_39_STABLE
+  - MOODLE_BRANCH=MOODLE_311_STABLE
 # This matrix is used for testing against multiple databases.  So for
 # each version of PHP being tested, one build will be created for each
 # database listed here.  EG: for PHP 7.3, one build will be created
@@ -61,16 +61,23 @@ env:
 #
 # jobs:
 #   include:
+#     - php: 8.0
+#       env: MOODLE_BRANCH=MOODLE_311_STABLE    DB=pgsql
+#     - php: 7.4
+#       env: MOODLE_BRANCH=MOODLE_311_STABLE    DB=pgsql
 #     - php: 7.3
-#       env: MOODLE_BRANCH=MOODLE_39_STABLE    DB=pgsql
-#     - php: 7.3
-#       env: MOODLE_BRANCH=MOODLE_39_STABLE    DB=mysqli
+#       env: MOODLE_BRANCH=MOODLE_311_STABLE    DB=mysqli
 #     ....
 # Note: this also enables to add specific env variables (NODE_VERSION,
 # EXTRA_PLUGINS...) per job, if you don't want to do it globally.
 
 # This lists steps that are run before the installation step.
 before_install:
+# Optional line: Only needed if going to run php8 jobs and the plugin
+# needs xmlrpc services.
+- if [[ ${TRAVIS_PHP_VERSION:0:1} -gt 7 ]]; then pecl install xmlrpc-beta; fi
+# Setup a good default max_input_vars value for all runs.
+- echo 'max_input_vars=5000' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 # This disables XDebug which should speed up the build.
   - phpenv config-rm xdebug.ini
 # Currently we are inside of the clone of your repository.  We move up two

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4']
-        moodle-branch: ['MOODLE_310_STABLE']
+        php: ['7.3', '7.4', '8.0']
+        moodle-branch: ['MOODLE_311_STABLE']
         database: [pgsql, mariadb]
 
     steps:
@@ -41,6 +41,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
           coverage: none
 
       - name: Initialise moodle-plugin-ci


### PR DESCRIPTION
Bumped to 3.1, because of the needed changes to get PHP 8 working.

Following https://moodlehq.github.io/moodle-plugin-ci/ReleaseNewVersion.html instructions

This must be incorporated without merge commit, for better tagging target.

Feel free to discuss any detail, I'm not the best writing this stuff!