### PR TITLE
Bump to fulfill 4.0 requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:10
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -102,6 +102,7 @@ jobs:
         moodle-plugin-ci mustache
         moodle-plugin-ci grunt ||  [ \
             "$MOODLE_BRANCH" != 'master' -a \
+            "$MOODLE_BRANCH" != 'MOODLE_311_STABLE' -a \
             "$MOODLE_BRANCH" != 'MOODLE_310_STABLE' -a \
             "$MOODLE_BRANCH" != 'MOODLE_39_STABLE' ]
         moodle-plugin-ci phpdoc

--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -1,7 +1,7 @@
 language: php
 
 addons:
-  postgresql: "9.6"
+  postgresql: "10"
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 addons:
-  postgresql: "9.6"
+  postgresql: "10"
 
 services:
   - mysql
@@ -48,6 +48,7 @@ script:
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt || [ \
         "$MOODLE_BRANCH" != 'master' -a \
+        "$MOODLE_BRANCH" != 'MOODLE_311_STABLE' -a \
         "$MOODLE_BRANCH" != 'MOODLE_310_STABLE' -a \
         "$MOODLE_BRANCH" != 'MOODLE_39_STABLE' ]
   - moodle-plugin-ci phpdoc

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-No unreleased changes.
+### Changed
+- Updated [gha.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/gha.dist.yml) and
+  [.travis.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/.travis.dist.yml)
+  to use PostgreSQL 10 (Moodle 4.0 new requirement).
+- ACTION REQUIRED: Existing integrations running tests with PostgreSQL now need to use version 10 or newer.
 
 ## [3.1.0] - 2021-05-14
 ### Added

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -31,7 +31,7 @@ jobs:
     # DB services you need for testing.
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:10
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -13,7 +13,7 @@ language: php
 
 # Installs the updated version of PostgreSQL and extra APT packages.
 addons:
-  postgresql: "9.6"
+  postgresql: "10"
 
 # Ensure DB and docker services are running.
 services:

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:10
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'


### PR DESCRIPTION
Basically:
  - postgres min version bumped to 10 (from previous 9.6).
  - exif php extension is now recommended.

For more info: https://tracker.moodle.org/browse/MDL-70594

This commit changes, all-together:

- Own GHA and Travis tests.
- GHA and Travis templates.
- Documentation and Changelog.