### PR TITLE
Remove ubuntu 16.04 from self-tests, out of support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   selftest:
     name: CI test (make validate)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out repository code
@@ -25,7 +25,7 @@ jobs:
   citest:
     name: CI test
     needs: selftest
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     services:
       postgres:


### PR DESCRIPTION
And being removed from the GHA setup-php

https://github.com/shivammathur/setup-php
https://github.com/shivammathur/setup-php/issues/452

So, jumping to 20.04 ~and also adding some mising php80 runs.~