### PR TITLE
fix #128 - add oracle support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
         ports:
         - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      oracle:
+        image: moodlehq/moodle-db-oracle-r2
+        env:
+          ORACLE_DISABLE_ASYNCH_IO: true
+        ports:
+          - 1521:1521
 
     strategy:
       fail-fast: false
@@ -44,18 +50,35 @@ jobs:
         include:
           - php: '7.4'
             moodle-branch: 'master'
+            database: 'pgsql'
+            extensions: 'mbstring, zip, gd, xmlrpc, soap, pgsql'
           - php: '7.4'
             moodle-branch: 'MOODLE_311_STABLE'
+            database: 'oci'
+            extensions: 'mbstring, zip, gd, xmlrpc, soap, oci8'
+            ciinstallparams: '--db-user moodle --db-pass "m@0dl3ing" --db-name XE'
           - php: '7.4'
             moodle-branch: 'MOODLE_310_STABLE'
+            database: 'pgsql'
+            extensions: 'mbstring, zip, gd, xmlrpc, soap, pgsql'
           - php: '7.4'
             moodle-branch: 'MOODLE_39_STABLE'
+            database: 'oci'
+            extensions: 'mbstring, zip, gd, xmlrpc, soap, oci8'
+            ciinstallparams: '--db-user moodle --db-pass "m@0dl3ing" --db-name XE'
           - php: '7.4'
             moodle-branch: 'MOODLE_38_STABLE'
+            database: 'pgsql'
+            extensions: 'mbstring, zip, gd, xmlrpc, soap, pgsql'
           - php: '7.2'
             moodle-branch: 'MOODLE_35_STABLE'
+            database: 'oci'
+            extensions: 'mbstring, zip, gd, xmlrpc, soap, oci8'
+            ciinstallparams: '--db-user moodle --db-pass "m@0dl3ing" --db-name XE'
           - php: '7.0'
             moodle-branch: 'MOODLE_35_STABLE'
+            database: 'pgsql'
+            extensions: 'mbstring, zip, gd, xmlrpc, soap, pgsql'
 
     steps:
     - name: Check out repository code
@@ -65,7 +88,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        extensions: pgsql, zip, gd, xmlrpc, soap
+        extensions: ${{ matrix.extensions }}
         coverage: none
 
     - name: Initialise moodle-plugin-ci
@@ -81,9 +104,9 @@ jobs:
         echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
 
     - name: Install moodle-plugin-ci
-      run: moodle-plugin-ci install -vvv
+      run: moodle-plugin-ci install -vvv ${{ matrix.ciinstallparams }}
       env:
-        DB: 'pgsql'
+        DB: ${{ matrix.database }}
         MOODLE_BRANCH: ${{ matrix.moodle-branch }}
         IGNORE_PATHS: 'ignore'
         IGNORE_NAMES: 'ignore_name.php'

--- a/res/template/config.php.txt
+++ b/res/template/config.php.txt
@@ -10,7 +10,7 @@ $CFG->dbhost    = '{{DBHOST}}';
 $CFG->dbname    = '{{DBNAME}}';
 $CFG->dbuser    = '{{DBUSER}}';
 $CFG->dbpass    = '{{DBPASS}}';
-$CFG->prefix    = 'mdl_';
+$CFG->prefix    = 'm_';
 $CFG->dboptions = [];
 
 $CFG->wwwroot  = '{{WWWROOT}}';
@@ -28,11 +28,11 @@ $CFG->noemailever    = true;
 $CFG->noreplyaddress = 'noreply@localhost.local';
 
 // PHPUnit settings.
-$CFG->phpunit_prefix   = 'phpu_';
+$CFG->phpunit_prefix   = 'p_';
 $CFG->phpunit_dataroot = '{{PHPUNITDATAROOT}}';
 
 // Behat settings.
-$CFG->behat_prefix        = 'behat_';
+$CFG->behat_prefix        = 'b_';
 $CFG->behat_dataroot      = '{{BEHATDATAROOT}}';
 $CFG->behat_wwwroot       = '{{BEHATWWWROOT}}';
 $CFG->behat_faildump_path = '{{BEHATDUMP}}';

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -89,7 +89,7 @@ class InstallCommand extends Command
             ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'Moodle repository to clone', $repo)
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Moodle git branch to clone, EG: MOODLE_29_STABLE', $branch)
             ->addOption('plugin', null, InputOption::VALUE_REQUIRED, 'Path to Moodle plugin', $plugin)
-            ->addOption('db-type', null, InputOption::VALUE_REQUIRED, 'Database type, mysqli, pgsql or mariadb', $type)
+            ->addOption('db-type', null, InputOption::VALUE_REQUIRED, 'Database type, mysqli, pgsql, mariadb or oci', $type)
             ->addOption('db-user', null, InputOption::VALUE_REQUIRED, 'Database user')
             ->addOption('db-pass', null, InputOption::VALUE_REQUIRED, 'Database pass', '')
             ->addOption('db-name', null, InputOption::VALUE_REQUIRED, 'Database name', 'moodle')

--- a/src/Installer/Database/DatabaseResolver.php
+++ b/src/Installer/Database/DatabaseResolver.php
@@ -60,7 +60,7 @@ class DatabaseResolver
                 return $database;
             }
         }
-        throw new \DomainException(sprintf('Unknown database type (%s). Please use mysqli, pgsql or mariadb.', $type));
+        throw new \DomainException(sprintf('Unknown database type (%s). Please use mysqli, pgsql, mariadb or oci.', $type));
     }
 
     /**
@@ -68,6 +68,6 @@ class DatabaseResolver
      */
     private function getDatabases()
     {
-        return [new MySQLDatabase(), new PostgresDatabase(), new MariaDBDatabase()];
+        return [new MySQLDatabase(), new PostgresDatabase(), new MariaDBDatabase(), new OracleDatabase()];
     }
 }

--- a/src/Installer/Database/OracleDatabase.php
+++ b/src/Installer/Database/OracleDatabase.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Copyright (c) 2018 Blackboard Inc. (http://www.blackboard.com)
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace MoodlePluginCI\Installer\Database;
+
+/**
+ * Oracle Database.
+ */
+class OracleDatabase extends AbstractDatabase
+{
+    public $type = 'oci';
+
+    public function getCreateDatabaseCommand()
+    {
+        return "echo 'All done!'";
+    }
+}

--- a/tests/Fixture/example-config.php
+++ b/tests/Fixture/example-config.php
@@ -10,7 +10,7 @@ $CFG->dbhost    = 'localhost';
 $CFG->dbname    = 'moodle';
 $CFG->dbuser    = 'root';
 $CFG->dbpass    = '';
-$CFG->prefix    = 'mdl_';
+$CFG->prefix    = 'm_';
 $CFG->dboptions = [];
 
 $CFG->wwwroot  = 'http://localhost/moodle';
@@ -28,11 +28,11 @@ $CFG->noemailever    = true;
 $CFG->noreplyaddress = 'noreply@localhost.local';
 
 // PHPUnit settings.
-$CFG->phpunit_prefix   = 'phpu_';
+$CFG->phpunit_prefix   = 'p_';
 $CFG->phpunit_dataroot = '/path/to/moodledata/phpu_moodledata';
 
 // Behat settings.
-$CFG->behat_prefix        = 'behat_';
+$CFG->behat_prefix        = 'b_';
 $CFG->behat_dataroot      = '/path/to/moodledata/behat_moodledata';
 $CFG->behat_wwwroot       = 'http://localhost:8000';
 $CFG->behat_faildump_path = '/path/to/moodledata/behat_dump';

--- a/tests/Installer/Database/DatabaseResolverTest.php
+++ b/tests/Installer/Database/DatabaseResolverTest.php
@@ -32,6 +32,10 @@ class DatabaseResolverTest extends \PHPUnit_Framework_TestCase
             'MoodlePluginCI\Installer\Database\MariaDBDatabase',
             $resolver->resolveDatabase('mariadb')
         );
+        $this->assertInstanceOf(
+            'MoodlePluginCI\Installer\Database\OracleDatabase',
+            $resolver->resolveDatabase('oci')
+        );
     }
 
     public function testTypeError()

--- a/tests/Installer/Database/OracleDatabaseTest.php
+++ b/tests/Installer/Database/OracleDatabaseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Copyright (c) 2018 Blackboard Inc. (http://www.blackboard.com)
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace MoodlePluginCI\Tests\Installer\Database;
+
+use MoodlePluginCI\Installer\Database\OracleDatabase;
+
+class OracleDatabaseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetCreateDatabaseCommand()
+    {
+        $database       = new OracleDatabase();
+        $database->name = 'TestName';
+        $database->user = 'TestUser';
+        $database->pass = 'TestPass';
+        $database->host = 'TestHost';
+
+        $expected = 'echo \'All done!\'';
+        $this->assertSame($expected, $database->getCreateDatabaseCommand());
+    }
+}


### PR DESCRIPTION
Use moodlehq/moodle-db-oracle as oracle backend.
For performance, we alternate db type testing for
every test included.