### PR TITLE
Support subplugins in install

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-No unreleased changes.
+### Added
+- Support for subplugins in the extra-plugins directory for install.
 
 ## [3.2.1] - 2021-07-30
 ### Changed

--- a/src/Bridge/MoodlePlugin.php
+++ b/src/Bridge/MoodlePlugin.php
@@ -61,6 +61,13 @@ class MoodlePlugin
     protected $dependencies;
 
     /**
+     * Cached subplugin types.
+     *
+     * @var string[]
+     */
+    protected $subpluginTypes;
+
+    /**
      * @param string $directory Absolute path to a Moodle plugin
      */
     public function __construct($directory)
@@ -136,6 +143,30 @@ class MoodlePlugin
         $this->dependencies = $filter->arrayStringKeys($assign->expr);
 
         return $this->dependencies;
+    }
+
+    /**
+     * Get a plugin's subplugin types.
+     *
+     * @return string[]
+     */
+    public function getSubpluginTypes()
+    {
+        // Simple cache.
+        if (is_array($this->subpluginTypes)) {
+            return $this->subpluginTypes;
+        }
+        $this->subpluginTypes = [];
+
+        $subpluginsJsonLocation = $this->directory . '/db/subplugins.json';
+        if (file_exists($subpluginsJsonLocation)) {
+            $subpluginData = json_decode(file_get_contents($subpluginsJsonLocation));
+            if ($subpluginData && property_exists($subpluginData, 'plugintypes')) {
+                $this->subpluginTypes = array_keys((array) $subpluginData->plugintypes);
+            }
+        }
+
+        return $this->subpluginTypes;
     }
 
     /**

--- a/src/Bridge/MoodlePlugin.php
+++ b/src/Bridge/MoodlePlugin.php
@@ -158,7 +158,7 @@ class MoodlePlugin
         }
         $this->subpluginTypes = [];
 
-        $subpluginsJsonLocation = $this->directory . '/db/subplugins.json';
+        $subpluginsJsonLocation = $this->directory.'/db/subplugins.json';
         if (file_exists($subpluginsJsonLocation)) {
             $subpluginData = json_decode(file_get_contents($subpluginsJsonLocation));
             if ($subpluginData && property_exists($subpluginData, 'plugintypes')) {

--- a/src/Bridge/MoodlePluginCollection.php
+++ b/src/Bridge/MoodlePluginCollection.php
@@ -52,6 +52,13 @@ class MoodlePluginCollection implements \Countable
             $elements[$item->getComponent()] = [];
         }
 
+        $subpluginTypes = [];
+        foreach ($this->items as $item) {
+            foreach ($item->getSubpluginTypes() as $type) {
+                $subpluginTypes[$type] = $item->getComponent();
+            }
+        }
+
         // Loop through a second time, only adding dependencies that exist in our list.
         foreach ($this->items as $item) {
             $dependencies = $item->getDependencies();
@@ -59,6 +66,12 @@ class MoodlePluginCollection implements \Countable
                 if (array_key_exists($dependency, $elements)) {
                     $elements[$item->getComponent()][] = $dependency;
                 }
+            }
+
+            // Add implied dependencies for subplugins.
+            list($type, $plugin) = explode('_', $item->getComponent(), 2);
+            if (array_key_exists($type, $subpluginTypes)) {
+                $elements[$item->getComponent()][] = $subpluginTypes[$type];
             }
         }
 

--- a/tests/Bridge/MoodlePluginCollectionTest.php
+++ b/tests/Bridge/MoodlePluginCollectionTest.php
@@ -75,4 +75,24 @@ class MoodlePluginCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($plugin3, $all[1]);
         $this->assertSame($plugin1, $all[2]);
     }
+
+    public function testSortByDependenciesWithSubplugins()
+    {
+        $plugin1               = new DummyMoodlePlugin('');
+        $plugin1->component    = 'mod_1';
+        $plugin1->subpluginTypes = ['subplugin'];
+
+        $plugin2               = new DummyMoodlePlugin('');
+        $plugin2->component    = 'subplugin_1';
+
+        $plugins = new MoodlePluginCollection();
+        $plugins->add($plugin2);
+        $plugins->add($plugin1);
+
+        $sorted = $plugins->sortByDependencies();
+        $all    = $sorted->all();
+        $this->assertCount(2, $all);
+        $this->assertSame($plugin1, $all[0]);
+        $this->assertSame($plugin2, $all[1]);
+    }
 }

--- a/tests/Bridge/MoodlePluginCollectionTest.php
+++ b/tests/Bridge/MoodlePluginCollectionTest.php
@@ -78,8 +78,8 @@ class MoodlePluginCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testSortByDependenciesWithSubplugins()
     {
-        $plugin1               = new DummyMoodlePlugin('');
-        $plugin1->component    = 'mod_1';
+        $plugin1                 = new DummyMoodlePlugin('');
+        $plugin1->component      = 'mod_1';
         $plugin1->subpluginTypes = ['subplugin'];
 
         $plugin2               = new DummyMoodlePlugin('');

--- a/tests/Bridge/MoodlePluginTest.php
+++ b/tests/Bridge/MoodlePluginTest.php
@@ -31,6 +31,14 @@ class MoodlePluginTest extends MoodleTestCase
         $this->assertSame(['mod_forum'], $plugin->getDependencies());
     }
 
+    public function testGetSubpluginTypes()
+    {
+        $plugintypes = ['subplugin' => 'some/plugin/dir'];
+        file_put_contents($this->pluginDir . '/db/subplugins.json', json_encode(['plugintypes' => $plugintypes]));
+        $plugin = new MoodlePlugin($this->pluginDir);
+        $this->assertSame(array_keys($plugintypes), $plugin->getSubpluginTypes());
+    }
+
     public function testHasUnitTests()
     {
         $plugin = new MoodlePlugin($this->pluginDir);

--- a/tests/Bridge/MoodlePluginTest.php
+++ b/tests/Bridge/MoodlePluginTest.php
@@ -34,7 +34,7 @@ class MoodlePluginTest extends MoodleTestCase
     public function testGetSubpluginTypes()
     {
         $plugintypes = ['subplugin' => 'some/plugin/dir'];
-        file_put_contents($this->pluginDir . '/db/subplugins.json', json_encode(['plugintypes' => $plugintypes]));
+        file_put_contents($this->pluginDir.'/db/subplugins.json', json_encode(['plugintypes' => $plugintypes]));
         $plugin = new MoodlePlugin($this->pluginDir);
         $this->assertSame(array_keys($plugintypes), $plugin->getSubpluginTypes());
     }

--- a/tests/Fake/Bridge/DummyMoodlePlugin.php
+++ b/tests/Fake/Bridge/DummyMoodlePlugin.php
@@ -18,4 +18,5 @@ class DummyMoodlePlugin extends MoodlePlugin
 {
     public $component    = 'local_ci';
     public $dependencies = ['mod_forum'];
+    public $subpluginTypes = [];
 }

--- a/tests/Fake/Bridge/DummyMoodlePlugin.php
+++ b/tests/Fake/Bridge/DummyMoodlePlugin.php
@@ -16,7 +16,7 @@ use MoodlePluginCI\Bridge\MoodlePlugin;
 
 class DummyMoodlePlugin extends MoodlePlugin
 {
-    public $component    = 'local_ci';
-    public $dependencies = ['mod_forum'];
+    public $component      = 'local_ci';
+    public $dependencies   = ['mod_forum'];
     public $subpluginTypes = [];
 }


### PR DESCRIPTION
The current implementation of the install command doesn't work as expected where the extra-plugins directory contains a plugin and a subplugin of that plugin. There is an implied dependency between the subplugin and the parent plugin which isn't accounted for, so the subplugin may be installed first, giving the following error:

> In Moodle.php line 113:                       
> The component metadatafieldtype_file has an unknown plugin type of metadatafieldtype

This can be reproduced by cloning the [local_metadata](https://github.com/PoetOS/moodle-local_metadata) plugin into the extra-plugins directory, and then moving the directories within the fieldtypes directory (which are subplugins) up to the root of the extra-plugins directory.