### PR TITLE
GitHub no longer supports the git:// protocol

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -844,7 +844,7 @@ Moodle repository to clone
 * Accept value: yes
 * Is value required: yes
 * Is multiple: no
-* Default: `'git://github.com/moodle/moodle.git'`
+* Default: `'https://github.com/moodle/moodle.git'`
 
 #### `--branch`
 

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -108,13 +108,13 @@ jobs:
 
       # Run the default install.
       # Optionally, it is possible to specify a different Moodle repo to use
-      # (git://github.com/moodle/moodle.git is used by default) and define
+      # (https://github.com/moodle/moodle.git is used by default) and define
       # ignore directives or any other env vars for install step.  For more
       # details on configuring for specific requirements please refer to the
       # 'Help' page.
       #
       # env:
-      #   MOODLE_REPO=git://github.com/username/moodle.git
+      #   MOODLE_REPO=https://github.com/username/moodle.git
       #   IGNORE_PATHS: 'ignore'
       #   IGNORE_NAMES: 'ignore_name.php'
       #   MUSTACHE_IGNORE_NAMES: 'broken.mustache'

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -50,8 +50,8 @@ env:
   - DB=mysqli
 
 # Optionally, it is possible to specify a different Moodle repo to use
-# (git://github.com/moodle/moodle.git is used by default):
-# - MOODLE_REPO=git://github.com/username/moodle.git
+# (https://github.com/moodle/moodle.git is used by default):
+# - MOODLE_REPO=https://github.com/username/moodle.git
 
 # Also, note that, for multi-branch scenarios, where the same plugin
 # codebase needs to be tested against multiple branches of Moodle,

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -69,7 +69,7 @@ class InstallCommand extends Command
     {
         // Travis CI configures some things by environment variables, default to those if available.
         $type   = getenv('DB') !== false ? getenv('DB') : null;
-        $repo   = getenv('MOODLE_REPO') !== false ? getenv('MOODLE_REPO') : 'git://github.com/moodle/moodle.git';
+        $repo   = getenv('MOODLE_REPO') !== false ? getenv('MOODLE_REPO') : 'https://github.com/moodle/moodle.git';
         $branch = getenv('MOODLE_BRANCH') !== false ? getenv('MOODLE_BRANCH') : null;
         $plugin = getenv('TRAVIS_BUILD_DIR') !== false ? getenv('TRAVIS_BUILD_DIR') : null;
         $paths  = getenv('IGNORE_PATHS') !== false ? getenv('IGNORE_PATHS') : null;


### PR DESCRIPTION
Mentioned at https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
I believe as I write this GitHub is in the midst of the first scheduled brown-out.