### PR TITLE
Coverage php has precedence

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,16 +10,6 @@
  * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$header = <<<'EOF'
-This file is part of the Moodle Plugin CI package.
-
-For the full copyright and license information, please view the LICENSE
-file that was distributed with this source code.
-
-Copyright (c) 2018 Blackboard Inc. (http://www.blackboard.com)
-License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
-EOF;
-
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
@@ -33,7 +23,6 @@ return (new PhpCsFixer\Config())
                                                        'expectedExceptionMessage',
                                                        'expectedExceptionMessageRegExp',
                                                    ]],
-        'header_comment'                        => ['header' => $header],
         'heredoc_to_nowdoc'                     => true,
         'no_extra_blank_lines'                  => ['tokens' => [
                                                        'break', 'continue', 'extra', 'return',

--- a/tests/Fake/Bridge/DummyMoodle311.php
+++ b/tests/Fake/Bridge/DummyMoodle311.php
@@ -1,0 +1,29 @@
+<?php
+
+// This file is part of the Moodle Plugin CI package.
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace MoodlePluginCI\Tests\Fake\Bridge;
+
+/**
+ * Dummy Moodle Fixture class to verify stuff like it's a plugin running for Moodle 3.11.
+ *
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class DummyMoodle311 extends DummyMoodle
+{
+    public $branch = 311;
+}

--- a/tests/Fixture/phpunit/coverage.php
+++ b/tests/Fixture/phpunit/coverage.php
@@ -1,0 +1,1 @@
+// This is a fake coverage.php file. Their contents aren't important at all, just its existence is.

--- a/tests/Fixture/phpunit/phpunit-311.xml
+++ b/tests/Fixture/phpunit/phpunit-311.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../lib/phpunit/phpunit.xsd"
+        bootstrap="../../lib/phpunit/bootstrap.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        printerClass="Hint_ResultPrinter"
+        testSuiteLoaderClass="phpunit_autoloader"
+>
+
+    <php>
+        <!--<const name="PHPUNIT_LONGTEST" value="1"/> uncomment to execute also slow or otherwise expensive tests-->
+        <const name="PHPUNIT_SEQUENCE_START" value="168000"/>
+
+        <!--Following constants instruct tests to fetch external test files from alternative location or skip tests if empty, clone https://github.com/moodlehq/moodle-exttests to local web server-->
+        <!--<const name="TEST_EXTERNAL_FILES_HTTP_URL" value="http://download.moodle.org/unittest"/> uncomment and alter to fetch external test files from alternative location-->
+        <!--<const name="TEST_EXTERNAL_FILES_HTTPS_URL" value="https://download.moodle.org/unittest"/> uncomment and alter to fetch external test files from alternative location-->
+    </php>
+
+
+    <testsuites>
+        <testsuite name="component_testsuite">
+            <directory suffix="_test.php">.</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">.</directory>
+        </include>
+        <exclude>
+            <directory suffix="_test.php">.</directory>
+        </exclude>
+    </coverage>
+
+</phpunit>

--- a/tests/Fixture/phpunit/phpunit-expected-311.xml
+++ b/tests/Fixture/phpunit/phpunit-expected-311.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../lib/phpunit/phpunit.xsd"
+        bootstrap="../../lib/phpunit/bootstrap.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        printerClass="Hint_ResultPrinter"
+        testSuiteLoaderClass="phpunit_autoloader"
+>
+
+    <php>
+        <!--<const name="PHPUNIT_LONGTEST" value="1"/> uncomment to execute also slow or otherwise expensive tests-->
+        <const name="PHPUNIT_SEQUENCE_START" value="168000"/>
+
+        <!--Following constants instruct tests to fetch external test files from alternative location or skip tests if empty, clone https://github.com/moodlehq/moodle-exttests to local web server-->
+        <!--<const name="TEST_EXTERNAL_FILES_HTTP_URL" value="http://download.moodle.org/unittest"/> uncomment and alter to fetch external test files from alternative location-->
+        <!--<const name="TEST_EXTERNAL_FILES_HTTPS_URL" value="https://download.moodle.org/unittest"/> uncomment and alter to fetch external test files from alternative location-->
+    </php>
+
+
+    <testsuites>
+        <testsuite name="component_testsuite">
+            <directory suffix="_test.php">.</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <file>classes/math.php</file>
+            <file>lib.php</file>
+        </include>
+    </coverage>
+
+</phpunit>

--- a/tests/Installer/TestSuiteInstallerTest.php
+++ b/tests/Installer/TestSuiteInstallerTest.php
@@ -15,6 +15,7 @@ namespace MoodlePluginCI\Tests\Installer;
 use MoodlePluginCI\Bridge\MoodlePlugin;
 use MoodlePluginCI\Installer\TestSuiteInstaller;
 use MoodlePluginCI\Tests\Fake\Bridge\DummyMoodle;
+use MoodlePluginCI\Tests\Fake\Bridge\DummyMoodle311;
 use MoodlePluginCI\Tests\Fake\Process\DummyExecute;
 use MoodlePluginCI\Tests\MoodleTestCase;
 use Symfony\Component\Yaml\Yaml;
@@ -93,5 +94,34 @@ class TestSuiteInstallerTest extends MoodleTestCase
         $this->fs->copy(__DIR__.'/../Fixture/phpunit/phpunit-33.xml', $xmlFile, true);
         $installer->injectPHPUnitFilter();
         $this->assertXmlFileEqualsXmlFile(__DIR__.'/../Fixture/phpunit/phpunit-expected.xml', $xmlFile);
+
+        // Test Moodle 3.3 PHPUnit when coverage.php is available.
+        $this->fs->copy(__DIR__.'/../Fixture/phpunit/phpunit-33.xml', $xmlFile, true);
+        $this->fs->copy(__DIR__.'/../Fixture/phpunit/coverage.php', $this->pluginDir.'/tests/coverage.php', true);
+        $installer->injectPHPUnitFilter();
+        // 3.3 did not support tests/coverage.php files, so defaults are applied normally.
+        $this->assertXmlFileEqualsXmlFile(__DIR__.'/../Fixture/phpunit/phpunit-expected.xml', $xmlFile);
+    }
+
+    public function testPHPUnitXMLFile311()
+    {
+        $xmlFile   = $this->pluginDir.'/phpunit.xml';
+        $installer = new TestSuiteInstaller(
+            new DummyMoodle311(''),
+            new MoodlePlugin($this->pluginDir),
+            new DummyExecute()
+        );
+
+        // Test Moodle 3.11 PHPUnit XML file.
+        $this->fs->copy(__DIR__.'/../Fixture/phpunit/phpunit-311.xml', $xmlFile, true);
+        $installer->injectPHPUnitFilter();
+        $this->assertXmlFileEqualsXmlFile(__DIR__.'/../Fixture/phpunit/phpunit-expected-311.xml', $xmlFile);
+
+        // Test Moodle 3.11 PHPUnit XML file when coverage.php is available.
+        $this->fs->copy(__DIR__.'/../Fixture/phpunit/phpunit-311.xml', $xmlFile, true);
+        $this->fs->copy(__DIR__.'/../Fixture/phpunit/coverage.php', $this->pluginDir.'/tests/coverage.php', true);
+        $installer->injectPHPUnitFilter();
+        // 3.11 supports tests/coverage.php files, so nothing is changed, expected file is the original one.
+        $this->assertXmlFileEqualsXmlFile(__DIR__.'/../Fixture/phpunit/phpunit-311.xml', $xmlFile);
     }
 }


### PR DESCRIPTION
This has to be considered / merged after #139 (it's built on top of it).

    Revamped phpunit code coverage analysis
    
    - Whenever a tests/coverage.php file is filter, don't apply
      code coverage defaults any more. That file is used by phpunit
      init to properly configure the desired coverage. This rule
      only applies when running tests against Moodle 3.7 and up.
    - Whenever we are using PHPUnit 9.5 and up, use the new coverage
      syntax where <filter><whitelist> became <coverage><include>. This
      rule only applies when running tests against Moodle 3.11 and up.
    - Covered with tests.
    
    Closes #93 and #120

Also:

    Remove the 'header_comment' rule from php-cs-fixer
    
    It was enforcing us to keep the Blackboard header for all files
    when new ones shouldn't be subject to that copyright notice.