### PR TITLE
Bump sub-tools to latest releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_codechecker",
-        "version": "3.0.2",
+        "version": "3.0.4",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
           "type": "git",
-          "reference": "v3.0.2"
+          "reference": "v3.0.4"
         }
       }
     },
@@ -52,11 +52,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_ci",
-        "version": "1.0.11",
+        "version": "1.0.12",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_ci.git",
           "type": "git",
-          "reference": "v1.0.11"
+          "reference": "v1.0.12"
         }
       }
     },
@@ -64,20 +64,20 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_moodlecheck",
-        "version": "1.0.8",
+        "version": "1.0.9",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_moodlecheck.git",
           "type": "git",
-          "reference": "v1.0.8"
+          "reference": "v1.0.9"
         }
       }
     }
   ],
   "require": {
     "php": ">=7.0.8",
-    "moodlehq/moodle-local_codechecker": "^3.0.2",
-    "moodlehq/moodle-local_ci": "^1.0.11",
-    "moodlehq/moodle-local_moodlecheck": "^1.0.8",
+    "moodlehq/moodle-local_codechecker": "^3.0.4",
+    "moodlehq/moodle-local_ci": "^1.0.12",
+    "moodlehq/moodle-local_moodlecheck": "^1.0.9",
     "sebastian/phpcpd": "^3.0",
     "phpmd/phpmd": "^2.2",
     "symfony/dotenv": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c90835d65c6a596fb8493b5021b0df04",
+    "content-hash": "de6ddb1d61b8a2cf506ec4a7cca704e9",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -199,46 +199,46 @@
         },
         {
             "name": "moodlehq/moodle-local_ci",
-            "version": "1.0.11",
+            "version": "1.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_ci.git",
-                "reference": "v1.0.11"
+                "reference": "v1.0.12"
             },
             "type": "library"
         },
         {
             "name": "moodlehq/moodle-local_codechecker",
-            "version": "3.0.2",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
-                "reference": "v3.0.2"
+                "reference": "v3.0.4"
             },
             "type": "library"
         },
         {
             "name": "moodlehq/moodle-local_moodlecheck",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_moodlecheck.git",
-                "reference": "v1.0.8"
+                "reference": "v1.0.9"
             },
             "type": "library"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.1",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/63a79e8daa781cac14e5195e63ed8ae231dd10fd",
-                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -279,9 +279,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2021-11-03T20:52:16+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "padraic/humbug_get_contents",
@@ -631,22 +631,22 @@
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.10.2",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "1bc74db7cf834662d83abebae265be11bb2eec3a"
+                "reference": "3637949092e6471aeaeca66bc6c016f45e459e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/1bc74db7cf834662d83abebae265be11bb2eec3a",
-                "reference": "1bc74db7cf834662d83abebae265be11bb2eec3a",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/3637949092e6471aeaeca66bc6c016f45e459e24",
+                "reference": "3637949092e6471aeaeca66bc6c016f45e459e24",
                 "shasum": ""
             },
             "require": {
                 "composer/xdebug-handler": "^1.0 || ^2.0",
                 "ext-xml": "*",
-                "pdepend/pdepend": "^2.10.0",
+                "pdepend/pdepend": "^2.10.2",
                 "php": ">=5.3.9"
             },
             "require-dev": {
@@ -702,7 +702,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/phpmd",
                 "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.10.2"
+                "source": "https://github.com/phpmd/phpmd/tree/2.11.0"
             },
             "funding": [
                 {
@@ -710,7 +710,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-22T09:56:23+00:00"
+            "time": "2021-11-29T14:05:52+00:00"
         },
         {
             "name": "phpunit/php-timer",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,14 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ## [Unreleased]
 ### Added
 - Support for subplugins in the extra-plugins directory for install.
+- Support for [`coverage.php`](https://docs.moodle.org/dev/Writing_PHPUnit_tests#Check_your_coverage) files added. Previous coverage defaults only will be applied when that file is not present in the plugin.
+
+### Changed
+- Updated project dependencies to current [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) versions.
+- Updated version of [moodle-local_codechecker](https://github.com/moodlehq/moodle-local_codechecker) to v3.0.4.
+- Both Chrome and Firefox are back to use latest Selenium 3 versions, previously pinned because of some interim problems with them.
+- GitHub [no longer supports the git:// protocol](https://github.blog/2021-09-01-improving-git-protocol-security-github/). Please change any use to `https://` instead.
+- Internal, various improvements to self testing.
 
 ## [3.2.1] - 2021-07-30
 ### Changed
@@ -80,7 +88,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 
 ### Changed
 - `moodle-plugin-ci phpunit` when coverage report is included, phpdbg is called with ignore memory limits param
-  to avoid memory exhaused errors.
+  to avoid memory exhausted errors.
 - Updated project dependencies to current [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) versions.
 - Updated version of [moodle-local_codechecker](https://github.com/moodlehq/moodle-local_codechecker) to v3.0.0.
 - Install grunt locally and use `npx grunt` to run it instead of installing it globally.

--- a/tests/Fixture/moodle-local_ci/tests/lib_test.php
+++ b/tests/Fixture/moodle-local_ci/tests/lib_test.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace local_ci;
+
 use local_ci\math;
 
 defined('MOODLE_INTERNAL') || die();
@@ -35,7 +37,7 @@ require_once(__DIR__.'/../lib.php');
  * @copyright Copyright (c) 2015 Blackboard Inc. (http://www.blackboard.com)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class local_ci_lib_testcase extends basic_testcase {
+class lib_test extends \basic_testcase {
     /**
      * Test addition.
      */
@@ -58,7 +60,7 @@ class local_ci_lib_testcase extends basic_testcase {
      * Test math class.
      */
     public function test_local_ci_math() {
-        $math = new local_ci_math();
+        $math = new \local_ci_math();
         $this->assertEquals(4, $math->add(2, 2));
         $this->assertEquals(2, $math->add(4, -2));
         $this->assertEquals(0, $math->add(-4, 4));


### PR DESCRIPTION
This needs to be merged after #141 
    
    This bumps local ci/moodlecheck/codechecker to the latest
    released / tags created last week.
    
    Also fixes a test caused by recent changes.
    
    Finally, unrelated with this, add to the CHANGELOG all the
    changes, still missing to be documented there, since last
    release of moodle-plugin-ci