### PR TITLE
Disable xdebug and pcov from self (validate) tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: 7.3
+        coverage: none
 
     - name: Initialise
       run: make init


### PR DESCRIPTION
We already were doing that in self (ci) tests and
also in recommended gha.dist.yml for plugins.

But for some reason (miss I imagine) we left this
validate test still installing both xdebug and then
using phpdbg for collecting coverage information.

And, as of today, it has started to crash (curiously,
it was not crashing earlier):

https://github.com/moodlehq/moodle-plugin-ci/actions/runs/1572798313

So, doing things properly, just disable any other covergae
extension because we use phpdbg.