### PR TITLE
Avoid forks to perform releases when they receive tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   release:
+    # Avoid forks to perform this job.
+    if: github.repository_owner == 'moodlehq'
     name: Create Release
     runs-on: ubuntu-18.04
 


### PR DESCRIPTION
Before this, forks getting the tags pushed were performing
own releases of moodle-plugin-ci. Let's run that job only
for the root "moodlehq" one.

You can see, for example, my "stronk7" fork, all releases
have happened also there:

https://github.com/stronk7/moodle-plugin-ci/releases

Ok, it seems to be working as expected:

1. I've created the 6.6.6 tag for the `no_release_on_forks` branch (that has the new condition), pushed it to my "stronk7" fork and only the "Moodle Plugin CI" workflow has been launched. The "Create Release" one is dimmed.
2. I've created the 7.7.7 tag for the `master` branch (that doesn't have the new condition), pushed it to my "stronk7" fork and both the  "Moodle Plugin CI" and the  "Create Release" workflows have been launched.
![no_create_release](https://user-images.githubusercontent.com/167147/149982506-fff15625-f1b6-4932-83b7-30a53f6c47e6.png)
3. So, only the [7.7.7 release has been performed](https://github.com/stronk7/moodle-plugin-ci/releases), not the 6.6.6 one.

So I think this is ready if we agree that it's better not to perform automated releases on forks.

Note: I'm removing both the 6.6.6 and 7.7.7 tags from my repo right now, to avoid them getting pushed upstream by mistake.

Ciao :-)