### PR TITLE
Use utf8mb4 for mysql and mariadb

### DIFF
--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -20,6 +20,9 @@ jobs:
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3

--- a/src/Installer/Database/MySQLDatabase.php
+++ b/src/Installer/Database/MySQLDatabase.php
@@ -24,7 +24,7 @@ class MySQLDatabase extends AbstractDatabase
         $passOpt  = !empty($this->pass) ? ' --password='.escapeshellarg($this->pass) : '';
         $user     = escapeshellarg($this->user);
         $host     = escapeshellarg($this->host);
-        $createDB = escapeshellarg(sprintf('CREATE DATABASE `%s` DEFAULT CHARACTER SET UTF8 COLLATE utf8_general_ci;', $this->name));
+        $createDB = escapeshellarg(sprintf('CREATE DATABASE `%s` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;', $this->name));
 
         return sprintf('mysql -u %s%s -h %s -e %s', $user, $passOpt, $host, $createDB);
     }

--- a/tests/Installer/Database/MariaDBDatabaseTest.php
+++ b/tests/Installer/Database/MariaDBDatabaseTest.php
@@ -24,7 +24,7 @@ class MariaDBDatabaseTest extends \PHPUnit\Framework\TestCase
         $database->pass = 'TestPass';
         $database->host = 'TestHost';
 
-        $expected = 'mysql -u \'TestUser\' --password=\'TestPass\' -h \'TestHost\' -e \'CREATE DATABASE `TestName` DEFAULT CHARACTER SET UTF8 COLLATE utf8_general_ci;\'';
+        $expected = 'mysql -u \'TestUser\' --password=\'TestPass\' -h \'TestHost\' -e \'CREATE DATABASE `TestName` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\'';
         $this->assertSame($expected, $database->getCreateDatabaseCommand());
     }
 }

--- a/tests/Installer/Database/MySQLDatabaseTest.php
+++ b/tests/Installer/Database/MySQLDatabaseTest.php
@@ -24,7 +24,7 @@ class MySQLDatabaseTest extends \PHPUnit\Framework\TestCase
         $database->pass = 'TestPass';
         $database->host = 'TestHost';
 
-        $expected = 'mysql -u \'TestUser\' --password=\'TestPass\' -h \'TestHost\' -e \'CREATE DATABASE `TestName` DEFAULT CHARACTER SET UTF8 COLLATE utf8_general_ci;\'';
+        $expected = 'mysql -u \'TestUser\' --password=\'TestPass\' -h \'TestHost\' -e \'CREATE DATABASE `TestName` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\'';
         $this->assertSame($expected, $database->getCreateDatabaseCommand());
     }
 }


### PR DESCRIPTION
Moodle 4.0 contains language strings that need the full 4 bytes UTF-8 code. So the MySQL and MariaDB moodle-plugin-ci databases should also support full unicode (issue #37).