### PR TITLE
Add --db-port option

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- `moodle-plugin-ci install` now provides an option `--db-port` to define a custom database port.
 
 ## [3.2.6] - 2022-05-10
 ### Changed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -813,7 +813,7 @@ Install everything required for CI testing
 
 ### Usage
 
-* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init] [--node-version NODE-VERSION]`
+* `install [--moodle MOODLE] [--data DATA] [--repo REPO] [--branch BRANCH] [--plugin PLUGIN] [--db-type DB-TYPE] [--db-user DB-USER] [--db-pass DB-PASS] [--db-name DB-NAME] [--db-host DB-HOST] [--db-port DB-PORT] [--not-paths NOT-PATHS] [--not-names NOT-NAMES] [--extra-plugins EXTRA-PLUGINS] [--no-init] [--node-version NODE-VERSION]`
 
 Install everything required for CI testing
 
@@ -908,6 +908,15 @@ Database host
 * Is value required: yes
 * Is multiple: no
 * Default: `'localhost'`
+
+#### `--db-port`
+
+Database port
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Default: `''`
 
 #### `--not-paths`
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -48,7 +48,7 @@
     </PossiblyNullIterator>
   </file>
   <file src="src/Command/InstallCommand.php">
-    <PossiblyInvalidArgument occurrences="12">
+    <PossiblyInvalidArgument occurrences="13">
       <code>$input-&gt;getOption('plugin')</code>
       <code>$pluginsDir</code>
       <code>$input-&gt;getOption('moodle')</code>
@@ -59,6 +59,7 @@
       <code>$input-&gt;getOption('db-user')</code>
       <code>$input-&gt;getOption('db-pass')</code>
       <code>$input-&gt;getOption('db-host')</code>
+      <code>$input-&gt;getOption('db-port')</code>
       <code>$input-&gt;getOption('not-paths')</code>
       <code>$input-&gt;getOption('not-names')</code>
     </PossiblyInvalidArgument>

--- a/res/template/config.php.txt
+++ b/res/template/config.php.txt
@@ -11,7 +11,9 @@ $CFG->dbname    = '{{DBNAME}}';
 $CFG->dbuser    = '{{DBUSER}}';
 $CFG->dbpass    = '{{DBPASS}}';
 $CFG->prefix    = 'mdl_';
-$CFG->dboptions = [];
+$CFG->dboptions = [
+    'dbport' => '{{DBPORT}}',
+];
 
 $CFG->wwwroot  = '{{WWWROOT}}';
 $CFG->dataroot = '{{DATAROOT}}';

--- a/src/Bridge/MoodleConfig.php
+++ b/src/Bridge/MoodleConfig.php
@@ -37,6 +37,7 @@ class MoodleConfig
             '{{DBTYPE}}'          => $database->type,
             '{{DBLIBRARY}}'       => $database->library,
             '{{DBHOST}}'          => $database->host,
+            '{{DBPORT}}'          => $database->port,
             '{{DBNAME}}'          => $database->name,
             '{{DBUSER}}'          => $database->user,
             '{{DBPASS}}'          => $database->pass,

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -94,6 +94,7 @@ class InstallCommand extends Command
             ->addOption('db-pass', null, InputOption::VALUE_REQUIRED, 'Database pass', '')
             ->addOption('db-name', null, InputOption::VALUE_REQUIRED, 'Database name', 'moodle')
             ->addOption('db-host', null, InputOption::VALUE_REQUIRED, 'Database host', 'localhost')
+            ->addOption('db-port', null, InputOption::VALUE_REQUIRED, 'Database port', '')
             ->addOption('not-paths', null, InputOption::VALUE_REQUIRED, 'CSV of file paths to exclude', $paths)
             ->addOption('not-names', null, InputOption::VALUE_REQUIRED, 'CSV of file names to exclude', $names)
             ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra)
@@ -174,7 +175,8 @@ class InstallCommand extends Command
             $input->getOption('db-name'),
             $input->getOption('db-user'),
             $input->getOption('db-pass'),
-            $input->getOption('db-host')
+            $input->getOption('db-host'),
+            $input->getOption('db-port')
         );
 
         return $factory;

--- a/src/Installer/Database/AbstractDatabase.php
+++ b/src/Installer/Database/AbstractDatabase.php
@@ -46,6 +46,13 @@ abstract class AbstractDatabase
     public $host = 'localhost';
 
     /**
+     * Database port.
+     *
+     * @var string
+     */
+    public $port = '';
+
+    /**
      * Moodle database type.
      *
      * @var string

--- a/src/Installer/Database/DatabaseResolver.php
+++ b/src/Installer/Database/DatabaseResolver.php
@@ -23,10 +23,11 @@ class DatabaseResolver
      * @param string|null $user
      * @param string|null $pass
      * @param string|null $host
+     * @param string|null $port
      *
      * @return AbstractDatabase
      */
-    public function resolveDatabase($type, $name = null, $user = null, $pass = null, $host = null)
+    public function resolveDatabase($type, $name = null, $user = null, $pass = null, $host = null, $port = null)
     {
         $database = $this->resolveDatabaseType($type);
 
@@ -41,6 +42,9 @@ class DatabaseResolver
         }
         if ($host !== null) {
             $database->host = $host;
+        }
+        if ($port !== null) {
+            $database->port = $port;
         }
 
         return $database;

--- a/src/Installer/Database/MySQLDatabase.php
+++ b/src/Installer/Database/MySQLDatabase.php
@@ -24,8 +24,9 @@ class MySQLDatabase extends AbstractDatabase
         $passOpt  = !empty($this->pass) ? ' --password='.escapeshellarg($this->pass) : '';
         $user     = escapeshellarg($this->user);
         $host     = escapeshellarg($this->host);
+        $port     = !empty($this->port) ? ' --port='.escapeshellarg($this->port) : '';
         $createDB = escapeshellarg(sprintf('CREATE DATABASE `%s` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;', $this->name));
 
-        return sprintf('mysql -u %s%s -h %s -e %s', $user, $passOpt, $host, $createDB);
+        return sprintf('mysql -u %s%s -h %s%s -e %s', $user, $passOpt, $host, $port, $createDB);
     }
 }

--- a/src/Installer/Database/PostgresDatabase.php
+++ b/src/Installer/Database/PostgresDatabase.php
@@ -25,8 +25,9 @@ class PostgresDatabase extends AbstractDatabase
         $pass     = !empty($this->pass) ? 'env PGPASSWORD='.escapeshellarg($this->pass).' ' : '';
         $user     = escapeshellarg($this->user);
         $host     = escapeshellarg($this->host);
+        $port     = !empty($this->port) ? ' --port '.escapeshellarg($this->port) : '';
         $createDB = escapeshellarg(sprintf('CREATE DATABASE "%s";', $this->name));
 
-        return sprintf('%spsql -c %s -U %s -h %s', $pass, $createDB, $user, $host);
+        return sprintf('%spsql -c %s -U %s -h %s%s', $pass, $createDB, $user, $host, $port);
     }
 }

--- a/tests/Fixture/example-config.php
+++ b/tests/Fixture/example-config.php
@@ -11,7 +11,9 @@ $CFG->dbname    = 'moodle';
 $CFG->dbuser    = 'root';
 $CFG->dbpass    = '';
 $CFG->prefix    = 'mdl_';
-$CFG->dboptions = [];
+$CFG->dboptions = [
+    'dbport' => '',
+];
 
 $CFG->wwwroot  = 'http://localhost/moodle';
 $CFG->dataroot = '/path/to/moodledata';

--- a/tests/Installer/Database/DatabaseResolverTest.php
+++ b/tests/Installer/Database/DatabaseResolverTest.php
@@ -49,8 +49,9 @@ class DatabaseResolverTest extends \PHPUnit\Framework\TestCase
         $user = 'TestUser';
         $pass = 'TestPass';
         $host = 'TestHost';
+        $port = 'TestPort';
 
-        $database = $resolver->resolveDatabase('mysqli', $name, $user, $pass, $host);
+        $database = $resolver->resolveDatabase('mysqli', $name, $user, $pass, $host, $port);
 
         $this->assertInstanceOf(
             'MoodlePluginCI\Installer\Database\MySQLDatabase',


### PR DESCRIPTION
Add support for non-default database ports. For example, you cannot run a MariaDB and MySQL database on the same host with the default ports.