### PR TITLE
PHPUnit should fail if there are warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,6 @@ jobs:
             "$MOODLE_BRANCH" != 'master' -a \
             "$MOODLE_BRANCH" != 'MOODLE_400_STABLE' ]
         moodle-plugin-ci phpdoc
-        moodle-plugin-ci phpunit --verbose --coverage-text
+        moodle-plugin-ci phpunit --verbose --coverage-text --fail-on-warning
         moodle-plugin-ci behat --profile default
         moodle-plugin-ci behat --profile chrome

--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -45,6 +45,6 @@ script:
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
-  - moodle-plugin-ci phpdoc
+  - moodle-plugin-ci phpdoc --fail-on-warning
   - moodle-plugin-ci phpunit
   - moodle-plugin-ci behat

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
         "$MOODLE_BRANCH" != 'MOODLE_310_STABLE' -a \
         "$MOODLE_BRANCH" != 'MOODLE_39_STABLE' ]
   - moodle-plugin-ci phpdoc
-  - moodle-plugin-ci phpunit --coverage-text
+  - moodle-plugin-ci phpunit --coverage-text --fail-on-warning
   - moodle-plugin-ci behat --profile default
   - moodle-plugin-ci behat --profile chrome
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- It is possible to specify more test execution options to the 'phpunit' command, such as "--fail-on-warning"
 
 ## [3.2.5] - 2022-03-31
 ### Changed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1735,7 +1735,7 @@ Run PHPUnit on a plugin
 
 ### Usage
 
-* `phpunit [-m|--moodle MOODLE] [--coverage-text] [--coverage-clover] [--] <plugin>`
+* `phpunit [-m|--moodle MOODLE] [--coverage-text] [--coverage-clover] [--fail-on-incomplete] [--fail-on-risky] [--fail-on-skipped] [--fail-on-warning] [--] <plugin>`
 
 Run PHPUnit on a plugin
 
@@ -1772,6 +1772,42 @@ Generate and print code coverage report in text format
 #### `--coverage-clover`
 
 Generate code coverage report in Clover XML format
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--fail-on-incomplete`
+
+Treat incomplete tests as failures
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--fail-on-risky`
+
+Treat risky tests as failures
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--fail-on-skipped`
+
+Treat skipped tests as failures
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--fail-on-warning`
+
+Treat tests with warnings as failures
 
 * Accept value: no
 * Is value required: no

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: PHPUnit tests
         if: ${{ always() }}
-        run: moodle-plugin-ci phpunit
+        run: moodle-plugin-ci phpunit --fail-on-warning
 
       - name: Behat features
         if: ${{ always() }}

--- a/src/Command/PHPUnitCommand.php
+++ b/src/Command/PHPUnitCommand.php
@@ -30,7 +30,11 @@ class PHPUnitCommand extends AbstractMoodleCommand
         $this->setName('phpunit')
             ->setDescription('Run PHPUnit on a plugin')
             ->addOption('coverage-text', null, InputOption::VALUE_NONE, 'Generate and print code coverage report in text format')
-            ->addOption('coverage-clover', null, InputOption::VALUE_NONE, 'Generate code coverage report in Clover XML format');
+            ->addOption('coverage-clover', null, InputOption::VALUE_NONE, 'Generate code coverage report in Clover XML format')
+            ->addOption('fail-on-incomplete', null, InputOption::VALUE_NONE, 'Treat incomplete tests as failures')
+            ->addOption('fail-on-risky', null, InputOption::VALUE_NONE, 'Treat risky tests as failures')
+            ->addOption('fail-on-skipped', null, InputOption::VALUE_NONE, 'Treat skipped tests as failures')
+            ->addOption('fail-on-warning', null, InputOption::VALUE_NONE, 'Treat tests with warnings as failures');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -73,6 +77,11 @@ class PHPUnitCommand extends AbstractMoodleCommand
         }
         if ($this->supportsCoverage() && $input->getOption('coverage-clover')) {
             $options[] = sprintf('--coverage-clover %s/coverage.xml', getcwd());
+        }
+        foreach (['fail-on-warning', 'fail-on-risky', 'fail-on-skipped', 'fail-on-warning'] as $option) {
+            if ($input->getOption($option)) {
+                $options[] = '--'.$option;
+            }
         }
         if (is_file($this->plugin->directory.'/phpunit.xml')) {
             $options[] = sprintf('--configuration %s', $this->plugin->directory);

--- a/tests/Fixture/moodle-local_ci/tests/lib_test.php
+++ b/tests/Fixture/moodle-local_ci/tests/lib_test.php
@@ -52,7 +52,7 @@ class lib_test extends \basic_testcase {
     /**
      * Test subtraction.
      *
-     * @covers ::local_ci_substract
+     * @covers ::local_ci_subtract
      */
     public function test_local_ci_subtract() {
         $this->assertEquals(0, local_ci_subtract(2, 2));
@@ -63,7 +63,7 @@ class lib_test extends \basic_testcase {
     /**
      * Test math class.
      *
-     * @covers \local_ci\math\add
+     * @covers \local_ci\math::add
      */
     public function test_local_ci_math() {
         $math = new \local_ci_math();
@@ -75,7 +75,7 @@ class lib_test extends \basic_testcase {
     /**
      * Test math class.
      *
-     * @covers \local_ci\math\add
+     * @covers \local_ci\math::add
      */
     public function test_local_ci_math_class() {
         $math = new math();


### PR DESCRIPTION
When there are warnings in the phpunit results the exit code is 0.

The typical warning we receive is incorrect "@covers" tag. The pipeline does not fail but the output shows that there are warnings:

```
$ . check moodle-plugin-ci phpunit --coverage-text
 RUN  PHPUnit tests for tool_tenant
Moodle 4.0 (Build: 20220419), b10a543752f72d95987b8672ecf0a1348cdc9bac
Php: 7.3.33, pgsql: 10.20 (Debian 10.20-1.pgdg90+1), OS: Linux 4.4.0-1052-aws x86_64
PHPUnit 9.5.13 by Sebastian Bergmann and contributors.
..........S.S.......................................WWWWW......  63 / 191 ( 32%)
........................................SSSSSSS................ 126 / 191 ( 65%)
.....................................................WWWWWWWWWW 189 / 191 ( 98%)
WW                                                              191 / 191 (100%)
Time: 00:33.950, Memory: 319.00 MB
There were 17 warnings:
1) tool_tenant\external_dashboard_test::test_reset_linked_dashboard
"@covers \tool_tenant\external\dashboard\" is invalid
phpvfscomposer:///builds/workplace/moodle/vendor/phpunit/phpunit/phpunit:97
2) tool_tenant\external_dashboard_test::test_reset_tenant_dashboard
"@covers \tool_tenant\external\dashboard\" is invalid
phpvfscomposer:///builds/workplace/moodle/vendor/phpunit/phpunit/phpunit:97
...
17) tool_tenant\users_report_test::test_subtenant_users_own_sub_tenant_showall
"@covers \tool_tenant\users_report" is invalid
phpvfscomposer:///builds/workplace/moodle/vendor/phpunit/phpunit/phpunit:97
WARNINGS!
Tests: 191, Assertions: 1202, Warnings: 17, Skipped: 9.
Code Coverage Report:        
  2022-04-21 20:36:07        

```

To test the patch I created test plugin that has warnings in @covers directives, here is the GHA file: https://github.com/marinaglancy/moodle-tool_testpluginci/blob/master/.github/workflows/test.yml
and here is the result of the GHA: https://github.com/marinaglancy/moodle-tool_testpluginci/runs/6117617797?check_suite_focus=true