### PR TITLE
Remove .phpcs.xml files immediately after creating it

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,9 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ### Changed
 - It is possible to specify more test execution options to the 'phpunit' command, such as "--fail-on-warning"
 
+### Fixed
+- Locally bundled [moodle-local_codechecker](https://github.com/moodlehq/moodle-local_codechecker) now works ok with recent (Moodle 3.11 and up) branches. A recent change in those versions was causing [some problems](https://tracker.moodle.org/browse/MDL-74704).
+
 ## [3.2.5] - 2022-03-31
 ### Changed
 - ACTION SUGGESTED: Now, it's safe to 'unpin' the MariaDB version in all integrations. With MariaDB 10.6.7 and 10.7.3 already released, the existing problems are gone, so it's possible to move away from the older 10.5 version. To achieve that, just look for any use of `image: mariadb:10.5` and change it to `image: mariadb:10`. For more information, see [MDL-72131](https://tracker.moodle.org/browse/MDL-72131).

--- a/src/Installer/VendorInstaller.php
+++ b/src/Installer/VendorInstaller.php
@@ -88,6 +88,15 @@ class VendorInstaller extends AbstractInstaller
         }
 
         $this->execute->mustRun(new Process('npx grunt ignorefiles', $this->moodle->directory, null, null, null));
+
+        // Remove the .phpcs files, recently introduced for 311_STABLE and up. At this stage moodle-plugin-ci
+        // is not ready to have them around, because of the way we run codechecker (from local_codechecker
+        // dependency).
+        // Once we remove that dependency and move to composer install of both phpcs and moodle-cs... there
+        // shouldn't be any more problems with these files and the following lines can be safely removed.
+        // So this is just an interim hack to allow moodle-plugin-ci to continue working the "legacy" way.
+        $this->execute->mustRun(new Process('rm -fr .phpcs.xml', $this->moodle->directory, null, null, null));
+        $this->execute->mustRun(new Process('rm -fr .phpcs.xml.dist', $this->moodle->directory, null, null, null));
     }
 
     public function stepCount()


### PR DESCRIPTION
moodle-plugin-ci is not ready for this yet. We need to move
from current use of local_codechecker to composer + moodle-cs
before being able to allow these new .phpcs.xml files in core.

So, for now, we are just deleting it as part of the tool
installation. This will be revisited when moving to the
new approach commented above.