### PR TITLE
Move to moodle cs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,18 +39,6 @@
     {
       "type": "package",
       "package": {
-        "name": "moodlehq/moodle-local_codechecker",
-        "version": "3.1.0",
-        "source": {
-          "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
-          "type": "git",
-          "reference": "v3.1.0"
-        }
-      }
-    },
-    {
-      "type": "package",
-      "package": {
         "name": "moodlehq/moodle-local_ci",
         "version": "1.0.12",
         "source": {
@@ -75,7 +63,7 @@
   ],
   "require": {
     "php": ">=7.0.8",
-    "moodlehq/moodle-local_codechecker": "^3.1",
+    "moodlehq/moodle-cs": "^3.2.3",
     "moodlehq/moodle-local_ci": "^1.0.12",
     "moodlehq/moodle-local_moodlecheck": "^1.0.9",
     "sebastian/phpcpd": "^3.0",
@@ -101,6 +89,9 @@
   "config": {
     "platform": {
       "php": "7.0.8"
+    },
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },
   "autoload": {
@@ -121,7 +112,6 @@
     "post-update-cmd": "@local-ci-install",
     "post-create-project-cmd": "@local-ci-install",
     "local-ci-install": [
-      "@composer remove --no-update --working-dir=vendor/moodlehq/moodle-local_ci squizlabs/php_codesniffer",
       "@composer update --prefer-dist --optimize-autoloader --working-dir=vendor/moodlehq/moodle-local_ci",
       "cd vendor/moodlehq/moodle-local_ci && npm install --no-progress"
     ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d6b457b1396170f7143d142bff90eec",
+    "content-hash": "f9a7fb1e23cd1273a26f9c928e1e5696",
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b"
+                "reference": "fd5dd441932a7e10ca6e5b490e272d34c8430640"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
-                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/fd5dd441932a7e10ca6e5b490e272d34c8430640",
+                "reference": "fd5dd441932a7e10ca6e5b490e272d34c8430640",
                 "shasum": ""
             },
             "require": {
@@ -64,7 +64,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.3.1"
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.2"
             },
             "funding": [
                 {
@@ -80,27 +80,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-28T20:44:15+00:00"
+            "time": "2022-05-24T11:56:16+00:00"
         },
         {
             "name": "composer/pcre",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2"
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/3d322d715c43a1ac36c7fe215fa59336265500f2",
-                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1",
+                "phpstan/phpstan": "^1.3",
                 "phpstan/phpstan-strict-rules": "^1.1",
                 "symfony/phpunit-bridge": "^4.2 || ^5"
             },
@@ -135,7 +135,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.0"
+                "source": "https://github.com/composer/pcre/tree/1.0.1"
             },
             "funding": [
                 {
@@ -151,20 +151,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-06T15:17:27+00:00"
+            "time": "2022-01-21T20:24:37+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "0c1a3925ec58a4ec98e992b9c7d171e9e184be0a"
+                "reference": "9e36aeed4616366d2b690bdce11f71e9178c579a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/0c1a3925ec58a4ec98e992b9c7d171e9e184be0a",
-                "reference": "0c1a3925ec58a4ec98e992b9c7d171e9e184be0a",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/9e36aeed4616366d2b690bdce11f71e9178c579a",
+                "reference": "9e36aeed4616366d2b690bdce11f71e9178c579a",
                 "shasum": ""
             },
             "require": {
@@ -201,7 +201,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.4"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.5"
             },
             "funding": [
                 {
@@ -217,7 +217,82 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-04T17:06:45+00:00"
+            "time": "2022-02-24T20:20:32+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "marcj/topsort",
@@ -271,22 +346,70 @@
             "time": "2016-11-19T14:58:11+00:00"
         },
         {
+            "name": "moodlehq/moodle-cs",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/moodlehq/moodle-cs.git",
+                "reference": "12ac0d4e56a7c9caa02a73725a089019742ad63c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/moodlehq/moodle-cs/zipball/12ac0d4e56a7c9caa02a73725a089019742ad63c",
+                "reference": "12ac0d4e56a7c9caa02a73725a089019742ad63c",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "replace": {
+                "moodlehq/moodle-local_codechecker": "3.1.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.6",
+                "overtrue/phplint": "^3.0",
+                "phpmd/phpmd": "^2.11",
+                "phpunit/phpunit": "^9.5",
+                "thor-juhasz/phpunit-coverage-check": "^0.3.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "MoodleHQ\\MoodleCS\\moodle\\": "moodle/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Andrew Lyons",
+                    "email": "andrew@nicols.co.uk"
+                }
+            ],
+            "description": "Moodle Coding Sniffer rules",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/moodlehq/moodle-cs/issues",
+                "source": "https://github.com/moodlehq/moodle-cs",
+                "wiki": "https://github.com/moodlehq/moodle-cs/wiki"
+            },
+            "time": "2022-04-17T07:35:46+00:00"
+        },
+        {
             "name": "moodlehq/moodle-local_ci",
             "version": "1.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_ci.git",
                 "reference": "v1.0.12"
-            },
-            "type": "library"
-        },
-        {
-            "name": "moodlehq/moodle-local_codechecker",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/moodlehq/moodle-local_codechecker.git",
-                "reference": "v3.1.0"
             },
             "type": "library"
         },
@@ -302,16 +425,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.2",
+            "version": "v4.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
                 "shasum": ""
             },
             "require": {
@@ -352,9 +475,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
             },
-            "time": "2021-11-30T19:35:32+00:00"
+            "time": "2022-05-31T20:59:12+00:00"
         },
         {
             "name": "padraic/humbug_get_contents",
@@ -390,13 +513,13 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Humbug\\": "src/"
-                },
                 "files": [
                     "src/function.php",
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Humbug\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -488,23 +611,23 @@
         },
         {
             "name": "pdepend/pdepend",
-            "version": "2.10.2",
+            "version": "2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "c8c1d2af43fb8c2b5387d50e9c42a9c56de13686"
+                "reference": "da3166a06b4a89915920a42444f707122a1584c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/c8c1d2af43fb8c2b5387d50e9c42a9c56de13686",
-                "reference": "c8c1d2af43fb8c2b5387d50e9c42a9c56de13686",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/da3166a06b4a89915920a42444f707122a1584c9",
+                "reference": "da3166a06b4a89915920a42444f707122a1584c9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.7",
-                "symfony/config": "^2.3.0|^3|^4|^5",
-                "symfony/dependency-injection": "^2.3.0|^3|^4|^5",
-                "symfony/filesystem": "^2.3.0|^3|^4|^5"
+                "symfony/config": "^2.3.0|^3|^4|^5|^6.0",
+                "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0",
+                "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0"
             },
             "require-dev": {
                 "easy-doc/easy-doc": "0.0.0|^1.2.3",
@@ -533,7 +656,7 @@
             "description": "Official version of pdepend to be handled with Composer",
             "support": {
                 "issues": "https://github.com/pdepend/pdepend/issues",
-                "source": "https://github.com/pdepend/pdepend/tree/2.10.2"
+                "source": "https://github.com/pdepend/pdepend/tree/2.10.3"
             },
             "funding": [
                 {
@@ -541,7 +664,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-16T20:05:32+00:00"
+            "time": "2022-02-23T07:53:09+00:00"
         },
         {
             "name": "php-parallel-lint/php-console-color",
@@ -647,16 +770,16 @@
         },
         {
             "name": "php-parallel-lint/php-parallel-lint",
-            "version": "v1.3.1",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
-                "reference": "761f3806e30239b5fcd90a0a45d41dc2138de192"
+                "reference": "6483c9832e71973ed29cf71bd6b3f4fde438a9de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/761f3806e30239b5fcd90a0a45d41dc2138de192",
-                "reference": "761f3806e30239b5fcd90a0a45d41dc2138de192",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/6483c9832e71973ed29cf71bd6b3f4fde438a9de",
+                "reference": "6483c9832e71973ed29cf71bd6b3f4fde438a9de",
                 "shasum": ""
             },
             "require": {
@@ -669,7 +792,7 @@
             },
             "require-dev": {
                 "nette/tester": "^1.3 || ^2.0",
-                "php-parallel-lint/php-console-highlighter": "~0.3",
+                "php-parallel-lint/php-console-highlighter": "0.* || ^1.0",
                 "squizlabs/php_codesniffer": "^3.6"
             },
             "suggest": {
@@ -681,7 +804,7 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "./"
+                    "./src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -698,28 +821,90 @@
             "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
             "support": {
                 "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
-                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.1"
+                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.2"
             },
-            "time": "2021-08-13T05:35:13+00:00"
+            "time": "2022-02-21T12:50:22+00:00"
         },
         {
-            "name": "phpmd/phpmd",
-            "version": "2.11.1",
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "08b60a2eb7e14c23f46ff8865b510ae08b75d0fd"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/08b60a2eb7e14c23f46ff8865b510ae08b75d0fd",
-                "reference": "08b60a2eb7e14c23f46ff8865b510ae08b75d0fd",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpmd/phpmd",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmd/phpmd.git",
+                "reference": "c0b678ba71902f539c27c14332aa0ddcf14388ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/c0b678ba71902f539c27c14332aa0ddcf14388ec",
+                "reference": "c0b678ba71902f539c27c14332aa0ddcf14388ec",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
                 "ext-xml": "*",
-                "pdepend/pdepend": "^2.10.2",
+                "pdepend/pdepend": "^2.10.3",
                 "php": ">=5.3.9"
             },
             "require-dev": {
@@ -775,7 +960,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/phpmd",
                 "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.11.1"
+                "source": "https://github.com/phpmd/phpmd/tree/2.12.0"
             },
             "funding": [
                 {
@@ -783,7 +968,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-17T11:25:43+00:00"
+            "time": "2022-03-24T13:33:01+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1087,6 +1272,62 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-12-12T21:44:58+00:00"
+        },
+        {
             "name": "stecman/symfony-console-completion",
             "version": "0.7.0",
             "source": {
@@ -1361,6 +1602,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": "symfony/error-handler",
             "time": "2020-10-24T10:57:07+00:00"
         },
         {
@@ -1669,12 +1911,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1748,12 +1990,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1931,22 +2173,25 @@
         },
         {
             "name": "theseer/fdomdocument",
-            "version": "1.6.6",
+            "version": "1.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/fDOMDocument.git",
-                "reference": "6e8203e40a32a9c770bcb62fe37e68b948da6dca"
+                "reference": "5cddd4f9076a9a2b85c5135935bba2dcb3ed7574"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/fDOMDocument/zipball/6e8203e40a32a9c770bcb62fe37e68b948da6dca",
-                "reference": "6e8203e40a32a9c770bcb62fe37e68b948da6dca",
+                "url": "https://api.github.com/repos/theseer/fDOMDocument/zipball/5cddd4f9076a9a2b85c5135935bba2dcb3ed7574",
+                "reference": "5cddd4f9076a9a2b85c5135935bba2dcb3ed7574",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "lib-libxml": "*",
                 "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "php": ">=7.3"
             },
             "type": "library",
             "autoload": {
@@ -1969,9 +2214,10 @@
             "homepage": "https://github.com/theseer/fDOMDocument",
             "support": {
                 "issues": "https://github.com/theseer/fDOMDocument/issues",
-                "source": "https://github.com/theseer/fDOMDocument/tree/master"
+                "source": "https://github.com/theseer/fDOMDocument/tree/1.6.7"
             },
-            "time": "2017-06-30T11:53:12+00:00"
+            "abandoned": true,
+            "time": "2022-01-25T23:10:35+00:00"
         }
     ],
     "packages-dev": [
@@ -2177,12 +2423,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,9 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 - PHPUnit code coverage will now automatically fallback between `pcov` => `xdebug` => `phpdbg`, using the "best" one available in the system. Still, if needed to, any of them can be forced, given all their requirements are fulfilled, using the following new options of the 'phpunit' command: `--coverage-pcov`, `--coverage-xdebug` or `--coverage-phpdbg`.
 - ACTION SUGGESTED: Ensure that the `pcov` or `xdebug` extensions are installed in your environment to get 'moodle-plugin-ci' using them automatically.
 
+### Changed
+- Switched from [local_codechecker]() to [moodle-cs]() for checking the coding style. Previously, `moodle-plugin-ci` (and other tools) required `local_codechecker` (that includes both `PHP_Codesniffer` and the `moodle` standard) to verify the coding style. Now, the `moodle` standard has been moved to be a standalone repository and all the tools will be using it and installing `PHP_Codesniffer` via composer. No changes in behavior are expected.
+
 ## [3.2.6] - 2022-05-10
 ### Added
 - It is possible to specify more test execution options to the 'phpunit' command, such as `--fail-on-incomplete`, `--fail-on-risky` and `--fail-on-skipped` and `--fail-on-warning`. For more information, see [PHPUnit documentation](https://phpunit.readthedocs.io).

--- a/src/Command/CodeCheckerCommand.php
+++ b/src/Command/CodeCheckerCommand.php
@@ -28,7 +28,7 @@ use Symfony\Component\Finder\Finder;
 //
 // The alternative is to, instead of using PHP_CodeSniffer like a library, just
 // use the binaries bundled with it (phpcs, phpcbf...) but we want to use as lib for now.
-require_once __DIR__.'/../../vendor/moodlehq/moodle-local_codechecker/phpcs/autoload.php';
+require_once __DIR__.'/../../vendor/squizlabs/php_codesniffer/autoload.php';
 
 /**
  * Run Moodle Code Checker on a plugin.
@@ -110,7 +110,7 @@ class CodeCheckerCommand extends AbstractPluginCommand
         //
         // Note: the paths are relative to the base CodeSniffer directory, aka, the directory
         // where "src" sits.
-        $runner->config->setConfigData('installed_paths', './../PHPCompatibility');
+        $runner->config->setConfigData('installed_paths', './../../phpcompatibility/php-compatibility/PHPCompatibility');
         $runner->config->standards = [$this->standard]; // Also BEFORE init() or it's lost.
 
         $runner->init();

--- a/src/Command/CodeCheckerCommand.php
+++ b/src/Command/CodeCheckerCommand.php
@@ -12,49 +12,31 @@
 
 namespace MoodlePluginCI\Command;
 
-use MoodlePluginCI\StandardResolver;
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Reporter;
-use PHP_CodeSniffer\Runner;
-use PHP_CodeSniffer\Util\Timing;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-
-// Cannot be autoload from composer, because this autoloader is used for both
-// phpcs and any standard Sniff, so it must be loaded at the end. For more info, see:
-// https://github.com/squizlabs/PHP_CodeSniffer/issues/1463#issuecomment-300637855
-//
-// The alternative is to, instead of using PHP_CodeSniffer like a library, just
-// use the binaries bundled with it (phpcs, phpcbf...) but we want to use as lib for now.
-require_once __DIR__.'/../../vendor/squizlabs/php_codesniffer/autoload.php';
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
- * Run Moodle Code Checker on a plugin.
+ * Run Moodle CodeSniffer standard on a plugin.
  */
 class CodeCheckerCommand extends AbstractPluginCommand
 {
-    /**
-     * The coding standard to use.
-     *
-     * @var string
-     */
-    protected $standard;
+    use ExecuteTrait;
 
     /**
-     * Used to find the files to process.
-     *
-     * @var Finder
+     * @var string Path to the temp file where the summary report results will be stored
      */
-    protected $finder;
+    protected $summaryFile;
 
     protected function configure()
     {
         parent::configure();
 
         $this->setName('codechecker')
-            ->setDescription('Run Moodle Code Checker on a plugin')
+            ->setDescription('Run Moodle CodeSniffer standard on a plugin')
             ->addOption('standard', 's', InputOption::VALUE_REQUIRED, 'The name or path of the coding standard to use', 'moodle')
             ->addOption('max-warnings', null, InputOption::VALUE_REQUIRED,
                 'Number of warnings to trigger nonzero exit code - default: -1', -1);
@@ -63,106 +45,69 @@ class CodeCheckerCommand extends AbstractPluginCommand
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         parent::initialize($input, $output);
-
-        // Resolve the coding standard.
-        $resolver       = new StandardResolver();
-        $this->standard = $input->getOption('standard');
-        if ($resolver->hasStandard($this->standard)) {
-            $this->standard = $resolver->resolve($this->standard);
-        }
-
-        $this->finder = Finder::create()->name('*.php');
+        $this->initializeExecute($output, $this->getHelper('process'));
+        $this->summaryFile = sys_get_temp_dir().'/moodle-plugin-ci-code-checker-summary-'.time();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->outputHeading($output, 'Moodle Code Checker on %s');
+        $this->outputHeading($output, 'Moodle CodeSniffer standard on %s');
 
-        $files = $this->plugin->getFiles($this->finder);
+        $files = $this->plugin->getFiles(Finder::create()->name('*.php'));
         if (count($files) === 0) {
             return $this->outputSkip($output);
         }
 
-        // Needed constant.
-        if (defined('PHP_CODESNIFFER_CBF') === false) {
-            define('PHP_CODESNIFFER_CBF', false);
+        $builder = ProcessBuilder::create()
+            ->setPrefix('php')
+            ->add(__DIR__.'/../../vendor/squizlabs/php_codesniffer/bin/phpcs')
+            ->add('--standard='.($input->getOption('standard') ?: 'moodle'))
+            ->add('--extensions=php')
+            ->add('-p')
+            ->add('-w')
+            ->add('-s')
+            ->add('--no-cache')
+            ->add($output->isDecorated() ? '--colors' : '--no-colors')
+            ->add('--report-full')
+            ->add('--report-width=132')
+            ->add('--encoding=utf-8')
+            ->setWorkingDirectory($this->plugin->directory)
+            ->setTimeout(null);
+
+        // If we aren't using the max-warnings option, then we can forget about warnings and tell phpcs
+        // to ignore them for exit-code purposes (still they will be reported in the output).
+        if ($input->getOption('max-warnings') < 0) {
+            $builder->add('--runtime-set')->add('ignore_warnings_on_exit')->add(' 1');
+        } else {
+            // If we are using the max-warnings option, we need the summary report somewhere to get
+            // the total number of errors and warnings from there.
+            $builder->add('--report-summary='.$this->summaryFile);
         }
 
-        Timing::startTiming();
-
-        $runner                    = new Runner();
-        $runner->config            = new Config(['--parallel=1']); // Pass a param to shortcut params coming from caller CLI.
-
-        // This is not needed normally, because phpcs loads the CodeSniffer.conf from its
-        // root directory. But when this is run from within a .phar file, it expects the
-        // config file to be out from the phar, in the same directory.
-        //
-        // While this approach is logic and enabled to configure phpcs, we don't want that
-        // in this case, we just want to ensure phpcs knows about our standards,
-        // so we are going to force the installed_paths config here.
-        //
-        // And it needs need to do it BEFORE the runner init! (or it's lost)
-        //
-        // Note: the "moodle" one is not really needed, because it's autodetected normally,
-        // but the PHPCompatibility one is. There are some issues about version PHPCompatibility 10
-        // to stop requiring to be configured here, but that's future version. Revisit this when
-        // available.
-        //
-        // Note: the paths are relative to the base CodeSniffer directory, aka, the directory
-        // where "src" sits.
-        $runner->config->setConfigData('installed_paths', './../../phpcompatibility/php-compatibility/PHPCompatibility');
-        $runner->config->standards = [$this->standard]; // Also BEFORE init() or it's lost.
-
-        $runner->init();
-
-        $runner->config->parallel     = 1;
-        $runner->config->reports      = ['full' => null];
-        $runner->config->colors       = $output->isDecorated();
-        $runner->config->verbosity    = 0;
-        $runner->config->encoding     = 'utf-8';
-        $runner->config->showProgress = true;
-        $runner->config->showSources  = true;
-        $runner->config->interactive  = false;
-        $runner->config->cache        = false;
-        $runner->config->extensions   = ['php' => 'PHP'];
-        $runner->config->reportWidth  = 132;
-
-        $runner->config->files = $files;
-
-        $runner->config->setConfigData('testVersion', PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION, true);
-
-        // Create the reporter to manage all the reports from the run.
-        $runner->reporter = new Reporter($runner->config);
-
-        // And build the file list to iterate over.
-        /** @var object[] $todo */
-        $todo         = new \PHP_CodeSniffer\Files\FileList($runner->config, $runner->ruleset);
-        $numFiles     = count($todo);
-        $numProcessed = 0;
-
-        foreach ($todo as $file) {
-            if ($file->ignored === false) {
-                try {
-                    $runner->processFile($file);
-                    ++$numProcessed;
-                    $runner->printProgress($file, $numFiles, $numProcessed);
-                } catch (\PHP_CodeSniffer\Exceptions\DeepExitException $e) {
-                    echo $e->getMessage();
-
-                    return $e->getCode();
-                } catch (\Exception $e) {
-                    $error = 'Problem during processing; checking has been aborted. The error message was: '.$e->getMessage();
-                    $file->addErrorOnLine($error, 1, 'Internal.Exception');
-                }
-                $file->cleanUp();
-            }
+        // Add the files to process.
+        foreach ($files as $file) {
+            $builder->add($file);
         }
 
-        // Have finished, generate the final reports.
-        $runner->reporter->printReports();
+        $process = $this->execute->passThroughProcess($builder->getProcess());
 
-        $maxwarnings = (int) $input->getOption('max-warnings');
+        // If we aren't using the max-warnings option, process exit code is enough for us.
+        if ($input->getOption('max-warnings') < 0) {
+            return $process->isSuccessful() ? 0 : 1;
+        }
 
-        return ($runner->reporter->totalErrors > 0 || ($maxwarnings >= 0 && $runner->reporter->totalWarnings > $maxwarnings)) ? 1 : 0;
+        // Arrived here, we are playing with max-warnings, so we have to decide the exit code
+        // based on the existence of errors and the number of warnings compared with the threshold.
+        $totalErrors   = 0;
+        $totalWarnings = 0;
+        $summary       = trim(file_get_contents($this->summaryFile));
+        if (preg_match('/^A TOTAL OF (\d+) ERRORS? AND (\d+) WARNINGS? WERE FOUND IN/m', $summary, $matches)) {
+            $totalErrors   = (int) $matches[1];
+            $totalWarnings = (int) $matches[2];
+        }
+        (new Filesystem())->remove($this->summaryFile);  // Remove the temporal summary file.
+
+        // With errors or warnings over the max-warnings threshold, fail the command.
+        return ($totalErrors > 0 || ($totalWarnings > $input->getOption('max-warnings'))) ? 1 : 0;
     }
 }

--- a/src/Command/CodeFixerCommand.php
+++ b/src/Command/CodeFixerCommand.php
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 //
 // The alternative is to, instead of using PHP_CodeSniffer like a library, just
 // use the binaries bundled with it (phpcs, phpcbf...) but we want to use as lib for now.
-require_once __DIR__.'/../../vendor/moodlehq/moodle-local_codechecker/phpcs/autoload.php';
+require_once __DIR__.'/../../vendor/squizlabs/php_codesniffer/autoload.php';
 
 /**
  * Run PHP Code Beautifier and Fixer on a plugin.
@@ -78,7 +78,7 @@ class CodeFixerCommand extends CodeCheckerCommand
         //
         // Note: the paths are relative to the base CodeSniffer directory, aka, the directory
         // where "src" sits.
-        $runner->config->setConfigData('installed_paths', './../PHPCompatibility');
+        $runner->config->setConfigData('installed_paths', './../../phpcompatibility/php-compatibility/PHPCompatibility');
         $runner->config->standards = [$this->standard]; // Also BEFORE init() or it's lost.
 
         $runner->init();

--- a/src/Command/CodeFixerCommand.php
+++ b/src/Command/CodeFixerCommand.php
@@ -12,21 +12,11 @@
 
 namespace MoodlePluginCI\Command;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Reporter;
-use PHP_CodeSniffer\Runner;
-use PHP_CodeSniffer\Util\Timing;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-
-// Cannot be autoload from composer, because this autoloader is used for both
-// phpcs and any standard Sniff, so it must be loaded at the end. For more info, see:
-// https://github.com/squizlabs/PHP_CodeSniffer/issues/1463#issuecomment-300637855
-//
-// The alternative is to, instead of using PHP_CodeSniffer like a library, just
-// use the binaries bundled with it (phpcs, phpcbf...) but we want to use as lib for now.
-require_once __DIR__.'/../../vendor/squizlabs/php_codesniffer/autoload.php';
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Run PHP Code Beautifier and Fixer on a plugin.
@@ -46,90 +36,33 @@ class CodeFixerCommand extends CodeCheckerCommand
     {
         $this->outputHeading($output, 'Code Beautifier and Fixer on %s');
 
-        $files = $this->plugin->getFiles($this->finder);
+        $files = $this->plugin->getFiles(Finder::create()->name('*.php'));
         if (count($files) === 0) {
-            return $this->outputSkip($output, 'No files found to process.');
+            return $this->outputSkip($output);
         }
 
-        // Needed constant.
-        if (defined('PHP_CODESNIFFER_CBF') === false) {
-            define('PHP_CODESNIFFER_CBF', true);
+        $builder = ProcessBuilder::create()
+            ->setPrefix('php')
+            ->add(__DIR__.'/../../vendor/squizlabs/php_codesniffer/bin/phpcbf')
+            ->add('--standard='.($input->getOption('standard') ?: 'moodle'))
+            ->add('--extensions=php')
+            ->add('-p')
+            ->add('-w')
+            ->add('-s')
+            ->add('--no-cache')
+            ->add($output->isDecorated() ? '--colors' : '--no-colors')
+            ->add('--report-full')
+            ->add('--report-width=132')
+            ->add('--encoding=utf-8')
+            ->setWorkingDirectory($this->plugin->directory)
+            ->setTimeout(null);
+
+        // Add the files to process.
+        foreach ($files as $file) {
+            $builder->add($file);
         }
 
-        Timing::startTiming();
-
-        $runner                    = new Runner();
-        $runner->config            = new Config(['--parallel=1']); // Pass a param to shortcut params coming from caller CLI.
-
-        // This is not needed normally, because phpcs loads the CodeSniffer.conf from its
-        // root directory. But when this is run from within a .phar file, it expects the
-        // config file to be out from the phar, in the same directory.
-        //
-        // While this approach is logic and enabled to configure phpcs, we don't want that
-        // in this case, we just want to ensure phpcs knows about our standards,
-        // so we are going to force the installed_paths config here.
-        //
-        // And it needs need to do it BEFORE the runner init! (or it's lost)
-        //
-        // Note: the "moodle" one is not really needed, because it's autodetected normally,
-        // but the PHPCompatibility one is. There are some issues about version PHPCompatibility 10
-        // to stop requiring to be configured here, but that's future version. Revisit this when
-        // available.
-        //
-        // Note: the paths are relative to the base CodeSniffer directory, aka, the directory
-        // where "src" sits.
-        $runner->config->setConfigData('installed_paths', './../../phpcompatibility/php-compatibility/PHPCompatibility');
-        $runner->config->standards = [$this->standard]; // Also BEFORE init() or it's lost.
-
-        $runner->init();
-
-        $runner->config->parallel     = 1;
-        $runner->config->reports      = ['cbf' => null];
-        $runner->config->colors       = $output->isDecorated();
-        $runner->config->verbosity    = 0;
-        $runner->config->encoding     = 'utf-8';
-        $runner->config->showProgress = true;
-        $runner->config->showSources  = true;
-        $runner->config->interactive  = false;
-        $runner->config->cache        = false;
-        $runner->config->extensions   = ['php' => 'PHP'];
-        $runner->config->reportWidth  = 132;
-
-        $runner->config->files = $files;
-
-        $runner->config->setConfigData('testVersion', PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION, true);
-
-        // Create the reporter to manage all the reports from the run.
-        $runner->reporter = new Reporter($runner->config);
-
-        // And build the file list to iterate over.
-        /** @var object[] $todo */
-        $todo         = new \PHP_CodeSniffer\Files\FileList($runner->config, $runner->ruleset);
-        $numFiles     = count($todo);
-        $numProcessed = 0;
-
-        foreach ($todo as $file) {
-            if ($file->ignored === false) {
-                try {
-                    $runner->processFile($file);
-                    ++$numProcessed;
-                    $runner->printProgress($file, $numFiles, $numProcessed);
-                } catch (\PHP_CodeSniffer\Exceptions\DeepExitException $e) {
-                    echo $e->getMessage();
-
-                    return $e->getCode();
-                } catch (\Exception $e) {
-                    $error = 'Problem during processing; checking has been aborted. The error message was: '.$e->getMessage();
-                    $file->addErrorOnLine($error, 1, 'Internal.Exception');
-                }
-                $file->cleanUp();
-            }
-        }
-
-        // Have finished, generate the final reports and timing.
-        $runner->reporter->printReports();
-        echo PHP_EOL;
-        Timing::printRunTime();
+        $this->execute->passThroughProcess($builder->getProcess());
 
         return 0;
     }

--- a/src/Installer/VendorInstaller.php
+++ b/src/Installer/VendorInstaller.php
@@ -88,15 +88,6 @@ class VendorInstaller extends AbstractInstaller
         }
 
         $this->execute->mustRun(new Process('npx grunt ignorefiles', $this->moodle->directory, null, null, null));
-
-        // Remove the .phpcs files, recently introduced for 311_STABLE and up. At this stage moodle-plugin-ci
-        // is not ready to have them around, because of the way we run codechecker (from local_codechecker
-        // dependency).
-        // Once we remove that dependency and move to composer install of both phpcs and moodle-cs... there
-        // shouldn't be any more problems with these files and the following lines can be safely removed.
-        // So this is just an interim hack to allow moodle-plugin-ci to continue working the "legacy" way.
-        $this->execute->mustRun(new Process('rm -fr .phpcs.xml', $this->moodle->directory, null, null, null));
-        $this->execute->mustRun(new Process('rm -fr .phpcs.xml.dist', $this->moodle->directory, null, null, null));
     }
 
     public function stepCount()

--- a/src/StandardResolver.php
+++ b/src/StandardResolver.php
@@ -31,7 +31,7 @@ class StandardResolver
     {
         $defaultStandards = [
             'moodle' => [
-                __DIR__.'/../vendor/moodlehq/moodle-local_codechecker/moodle',
+                __DIR__.'/../vendor/moodlehq/moodle-cs/moodle',
             ],
         ];
 

--- a/tests/Command/CodeFixerCommandTest.php
+++ b/tests/Command/CodeFixerCommandTest.php
@@ -72,19 +72,18 @@ EOT;
 
     public function testExecute()
     {
-        $this->expectOutputRegex('/\.+/'); // Trick to avoid output, real assertions below.
         $commandTester = $this->executeCommand();
         $this->assertSame(0, $commandTester->getStatusCode());
 
         // Verify various parts of the output.
-        $output = $this->getActualOutput();
+        $output = $commandTester->getDisplay();
         $this->assertRegExp('/F\.* 8\.* \/ 8 \(100%\)/', $output);                   // Progress.
         $this->assertRegExp('/\/fixable.php/', $output);                            // File.
         $this->assertRegExp('/A TOTAL OF 1 ERROR WERE FIXED IN 1 FILE/', $output);  // Summary.
         $this->assertRegExp('/Time:.*Memory:/', $output);                           // Time.
 
         // Also verify display info is correct.
-        $this->assertRegExp('/RUN  Code Beautifier and Fixer/', $commandTester->getDisplay());
+        $this->assertRegExp('/RUN  Code Beautifier and Fixer on local_ci/', $output);
 
         $expected = <<<'EOT'
 <?php
@@ -97,5 +96,14 @@ if (true) {
 
 EOT;
         $this->assertSame($expected, file_get_contents($this->pluginDir.'/fixable.php'));
+    }
+
+    public function testExecuteNoFiles()
+    {
+        // Just random directory with no PHP files.
+        $commandTester = $this->executeCommand($this->pluginDir.'/tests/behat');
+        $this->assertSame(0, $commandTester->getStatusCode());
+
+        $this->assertRegExp('/No relevant files found to process, free pass!/', $commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
In summary, this makes moodle-plugin-ci to stop using local_codechecker as a requirement and starts using the, now split, moodle-cs standard (with both it and PHP_CodeSniffer being installed via composer).

That was, any new sniff added to the standard and released, or any new PHP_Codesniffer version will be used immediately, without having to make "fake" local_codechecker releases anymore.

Note this PR has 2 commits:

1. The first just does the switch but continues using PHP_Codesniffer as a library, within PHP like it was an API. This API use was causing some problems, specially like #167, affecting all current versions (both before and after the commit).
2. The second commit makes the change from library to binary so, now, we use the `phpcs` binary passing everything from CLI / shell execution. It's way clearer and less hacky.3. 

All the existing features have been apparently (covered with new tests) preserved and all the testing, namely:
- moodle-plugin-ci itself
- local executions
- github, travis and gitlab executions

Are passing without the problems commented in #167 any more.

And that's this. One less tool using local_codechecker (the last one, so far), so we can continue with https://github.com/moodlehq/moodle-local_codechecker/pull/193 (making codechecker itself to use the standalone standard).

Ciao :-)