### PR TITLE
Changes to guarantee that --version works always

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -54,5 +54,6 @@ return (new PhpCsFixer\Config())
             ->exclude('moodle')
             ->exclude('moodledata')
             ->name('moodle-plugin-ci')
+            ->name('validate-version')
             ->in(__DIR__)
     );

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,17 @@ test-phpunit: check-init
 	$(PHPUNIT) --verbose
 
 .PHONY:validate
-validate: check-init psalm check-docs
+validate: check-init validate-version psalm check-docs
 	$(FIXER) fix --dry-run --stop-on-violation
 	$(COMPOSER) validate
 	XDEBUG_MODE=coverage $(PHPUNIT) --verbose --coverage-text
 
 .PHONY:build
 build: build/moodle-plugin-ci.phar
+
+.PHONY:validate-version
+validate-version:
+	bin/validate-version
 
 .PHONY:psalm
 psalm: check-init
@@ -41,7 +45,7 @@ check-docs: docs/CLI.md
 .PHONY: init
 init: build/php-cs-fixer.phar build/psalm.phar composer.lock composer.json
 	$(COMPOSER) selfupdate
-	$(COMPOSER) install --no-suggest --no-progress
+	$(COMPOSER) install --no-progress
 
 .PHONY: update
 update: check-init build/php-cs-fixer.phar build/psalm.phar

--- a/bin/moodle-plugin-ci
+++ b/bin/moodle-plugin-ci
@@ -45,6 +45,9 @@ if (file_exists(__DIR__.'/../../../autoload.php')) {
     exit(1);
 }
 
+// Current version. Keep it updated on releases.
+define('MOODLE_PLUGIN_CI_VERSION', '3.2.6');
+
 define('MOODLE_PLUGIN_CI_BOXED', '@is_boxed@');
 define('ENV_FILE', dirname(__DIR__).'/.env');
 
@@ -56,7 +59,13 @@ if (file_exists(ENV_FILE)) {
     $env->load(ENV_FILE);
 }
 
-$application = new Application('Moodle Plugin CI', '@package_version@');
+$version = (new \SebastianBergmann\Version(MOODLE_PLUGIN_CI_VERSION, dirname(__DIR__)))->getVersion();
+// Let's make Box to find the better version for the phar from git.
+if (MOODLE_PLUGIN_CI_BOXED === 'BOXED') {
+    $version = '@package_version@';
+}
+
+$application = new Application('Moodle Plugin CI', $version);
 $application->add(new AddConfigCommand());
 $application->add(new AddPluginCommand(ENV_FILE));
 $application->add(new BehatCommand());

--- a/bin/validate-version
+++ b/bin/validate-version
@@ -1,0 +1,66 @@
+#!/usr/bin/env php
+<?php
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * Verify that the version in the moodle-plugin-ci app matches the
+ * most recent version in the docs/CHANGELOG.md file. That way we
+ * will enforce both to be always changed together, as part of the
+ * documented release process.
+ */
+
+// We need the moodle-plugin-ci binary, error if not found.
+$binary = __DIR__.'/moodle-plugin-ci';
+if (!is_readable($binary)) {
+    fwrite(STDERR, 'Failed to find moodle-plugin-ci binary (usually under the bin directory).'.PHP_EOL);
+    exit(1);
+}
+
+// We need the docs/CHANGELOG.md, error if not found.
+$changelog = dirname(__DIR__).'/docs/CHANGELOG.md';
+if (!is_readable($changelog)) {
+    fwrite(STDERR, 'Failed to find CHANGELOG.md (usually under the docs directory).'.PHP_EOL);
+    exit(1);
+}
+
+// Extract the version from the binary, error if not found.
+$regexp = '~^define\(\'MOODLE_PLUGIN_CI_VERSION\', *[\'"](\d+\.\d+\.\d+)[\'"].*$~m';
+if (!preg_match($regexp, file_get_contents($binary), $binaryMatches)) {
+    fwrite(STDERR, 'Failed to parse moodle-plugin-ci looking for a version.'.PHP_EOL);
+    exit(1);
+}
+$binaryVersion = $binaryMatches[1];
+
+// Extract the version from the change log, error if not found.
+$regexp = '~^## *\[(\d+\.\d+\.\d+)\] *\-* *\d{4}\-\d{1,2}\-\d{1,2}$~m';
+if (!preg_match($regexp, file_get_contents($changelog), $changelogMatches)) {
+    fwrite(STDERR, 'Failed to parse CHANGELOG.md looking for a version.'.PHP_EOL);
+    exit(1);
+}
+$changelogVersion = $changelogMatches[1];
+
+// Version in change log > binary, error.
+if (version_compare($changelogVersion, $binaryVersion, '>')) {
+    fwrite(STDERR, 'Version in docs/CHANGELOG.md ('.
+        $changelogVersion.') is newer than version in bin/moodle-plugin-ci ('.
+        $binaryVersion.'). Please, check!'.PHP_EOL);
+    exit(1);
+}
+
+// Version in change log < binary, error.
+if (version_compare($changelogVersion, $binaryVersion, '<')) {
+    fwrite(STDERR, 'Version in docs/CHANGELOG.md ('.
+        $changelogVersion.') is older than version in bin/moodle-plugin-ci ('.
+        $binaryVersion.'). Please, check!'.PHP_EOL);
+    exit(1);
+}
+
+// Arrived here, versions match, all ok.
+fwrite(STDOUT, 'Matching version found: '.$changelogVersion.PHP_EOL);
+exit(0);

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     "moodlehq/moodle-local_ci": "^1.0.12",
     "moodlehq/moodle-local_moodlecheck": "^1.0.9",
     "sebastian/phpcpd": "^3.0",
+    "sebastian/version": "^2.0.1",
     "phpmd/phpmd": "^2.2",
     "symfony/dotenv": "^3.4",
     "symfony/filesystem": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9a7fb1e23cd1273a26f9c928e1e5696",
+    "content-hash": "bea33fe979ed03f96c1ee4d84b81b1c0",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1273,16 +1273,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -1325,7 +1325,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "stecman/symfony-console-completion",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ### Changed
 - Switched from [local_codechecker](https://github.com/moodlehq/moodle-local_codechecker) to [moodle-cs](https://github.com/moodlehq/moodle-cs) for checking the coding style. Previously, `moodle-plugin-ci` (and other tools) required `local_codechecker` (that includes both `PHP_Codesniffer` and the `moodle` standard) to verify the coding style. Now, the `moodle` standard has been moved to be a standalone repository and all the tools will be using it and installing `PHP_Codesniffer` via composer. No changes in behavior are expected.
 
+### Fixed
+- The `--version` option now works both with the `bin/moodle-plugin-ci` binary and the `moodle-plugin-ci.phar` package.
+
 ## [3.2.6] - 2022-05-10
 ### Added
 - It is possible to specify more test execution options to the 'phpunit' command, such as `--fail-on-incomplete`, `--fail-on-risky` and `--fail-on-skipped` and `--fail-on-warning`. For more information, see [PHPUnit documentation](https://phpunit.readthedocs.io).

--- a/docs/ReleaseNewVersion.md
+++ b/docs/ReleaseNewVersion.md
@@ -10,6 +10,8 @@ Prior to tagging a release, ensure the following have been updated:
 
 * The `CHANGELOG.md` needs to be up-to-date.  In addition, the _Unreleased_ section needs to be updated
   with the version being released.  Also update the _Unreleased_ link at the bottom with the new version number.
+* The `bin/moodle-plugin-ci` also needs to be updated accordingly, setting the `MOODLE_PLUGIN_CI_VERSION` constant
+  to the version being released.
 * If this is a new major version, then CI tool example files and its docs need
   to be updated to use the new major version (e.g. for Travis CI make changes
   in `.travis.dist.yml` and `doc/TravisFileExplained.md`). Any other version


### PR DESCRIPTION
IMPORTANT: This needs to be merged after #171 is merged and this has been rebased (composer regenerated).

With this change:

1. moodle-plugin-ci.phar will continue working the same,
   with `--version` always returning the correct (git describe)
   version used to build the phar.
2. bin/moodle-plugin-ci will also show the correct (git describe)
   version, when it's run from a git directory. If not git is detected
   the version specified in `$version` will be used.

Plus:

- In order to ensure that the `$version` is updated on every release a
  new check has been added to `make validate`. It will compare the
  latest version documented in the 'docs/CHANGELOG.md' file with the
  version in the `bin/moodle-plugin-ci` file.
- Release docs have been amended to remember to update the version
  in `bin/moodle-plugin-ci` when making a release.

Fixes #169