### PR TITLE
Prepare 3 3 0

### DIFF
--- a/bin/moodle-plugin-ci
+++ b/bin/moodle-plugin-ci
@@ -46,7 +46,7 @@ if (file_exists(__DIR__.'/../../../autoload.php')) {
 }
 
 // Current version. Keep it updated on releases.
-define('MOODLE_PLUGIN_CI_VERSION', '3.2.6');
+define('MOODLE_PLUGIN_CI_VERSION', '3.3.0');
 
 define('MOODLE_PLUGIN_CI_BOXED', '@is_boxed@');
 define('ENV_FILE', dirname(__DIR__).'/.env');

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+
+## [3.3.0] - 2022-06-28
 ### Added
 - PHPUnit code coverage will now automatically fallback between `pcov` => `xdebug` => `phpdbg`, using the "best" one available in the system. Still, if needed to, any of them can be forced, given all their requirements are fulfilled, using the following new options of the 'phpunit' command: `--coverage-pcov`, `--coverage-xdebug` or `--coverage-phpdbg`.
 - ACTION SUGGESTED: Ensure that the `pcov` or `xdebug` extensions are installed in your environment to get 'moodle-plugin-ci' using them automatically.
@@ -416,7 +418,8 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 - `moodle-plugin-ci shifter` command.  Run YUI Shifter on plugin YUI modules.
 - `moodle-plugin-ci csslint` command.  Lints the CSS files in the plugin.
 
-[Unreleased]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.2.6...master
+[Unreleased]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.3.0...master
+[3.3.0]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.2.6...3.3.0
 [3.2.6]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.2.5...3.2.6
 [3.2.5]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.2.4...3.2.5
 [3.2.4]: https://github.com/moodlehq/moodle-plugin-ci/compare/3.2.3...3.2.4

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -376,13 +376,13 @@ Do not ask any interactive question
 `codechecker`
 -------------
 
-Run Moodle Code Checker on a plugin
+Run Moodle CodeSniffer standard on a plugin
 
 ### Usage
 
 * `codechecker [-s|--standard STANDARD] [--max-warnings MAX-WARNINGS] [--] <plugin>`
 
-Run Moodle Code Checker on a plugin
+Run Moodle CodeSniffer standard on a plugin
 
 ### Arguments
 
@@ -1735,7 +1735,7 @@ Run PHPUnit on a plugin
 
 ### Usage
 
-* `phpunit [-m|--moodle MOODLE] [--coverage-text] [--coverage-clover] [--fail-on-incomplete] [--fail-on-risky] [--fail-on-skipped] [--fail-on-warning] [--] <plugin>`
+* `phpunit [-m|--moodle MOODLE] [--coverage-text] [--coverage-clover] [--coverage-pcov] [--coverage-xdebug] [--coverage-phpdbg] [--fail-on-incomplete] [--fail-on-risky] [--fail-on-skipped] [--fail-on-warning] [--] <plugin>`
 
 Run PHPUnit on a plugin
 
@@ -1772,6 +1772,33 @@ Generate and print code coverage report in text format
 #### `--coverage-clover`
 
 Generate code coverage report in Clover XML format
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--coverage-pcov`
+
+Use the pcov extension to calculate code coverage
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--coverage-xdebug`
+
+Use the xdebug extension to calculate code coverage
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--coverage-phpdbg`
+
+Use the phpdbg binary to calculate code coverage
 
 * Accept value: no
 * Is value required: no


### PR DESCRIPTION
I've decided to bump it to 3.3.0 (instead of 3.2.6) because of the internal changes from moodle-local_codechecker to moodle-cs. Just in case anybody needs to staty sticky to 3.2.x or something like that.

Also, the CLI docs have been updated with auto-generated new options. And the version has been updated in the new place (bin/moodle-plugin-ci) as indicated by the release instructions.

Don't forget that this has to be added WITHOUT merge commit, use squash or rebase instead.

Ciao :-)