### PR TITLE
Bump self-tests to 4.1 requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -1,11 +1,14 @@
 language: php
 
 addons:
-  postgresql: "10"
+  postgresql: "12"
+  apt:
+    packages:
+      - postgresql-12
+      - postgresql-client-12
 
 services:
   - mysql
-  - postgresql
   - docker
 
 cache:
@@ -20,6 +23,7 @@ php:
 
 env:
  global:
+  - PGVER=12
   - MOODLE_BRANCH=MOODLE_311_STABLE
  matrix:
   - DB=pgsql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: php
 
 addons:
-  postgresql: "10"
+  postgresql: "12"
+  apt:
+    packages:
+      - postgresql-12
+      - postgresql-client-12
 
 services:
   - mysql
-  - postgresql
   - docker
 
 cache:
@@ -18,6 +21,7 @@ php:
 
 env:
   global:
+    - PGVER=12
     - IGNORE_PATHS=ignore
     - IGNORE_NAMES=ignore_name.php
     - MUSTACHE_IGNORE_NAMES=broken.mustache

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,16 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ### Added
 - `moodle-plugin-ci install` now provides an option `--db-port` to define a custom database port.
 
+### Changed
+- Updated [gha.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/gha.dist.yml) and
+  [.travis.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/.travis.dist.yml)
+  (and documentation) to fulfil [Moodle 4.1 new requirements](https://tracker.moodle.org/browse/MDL-71747).
+- ACTION REQUIRED: Review existing integrations running tests against master (4.1dev). There are a few Moodle 4.1 new requirements:
+  - PHP 7.4 is required (instead of 7.3).
+  - PostgreSQL 12 is required (instead of 10). Pay special attention to the changes needed for this and Travis!
+  - MariaDB 10.4 is required (instead of 10.2.29).
+  - Oracle 19 is required (instead of 11.2).
+
 ## [3.3.0] - 2022-06-28
 ### Added
 - PHPUnit code coverage will now automatically fallback between `pcov` => `xdebug` => `phpdbg`, using the "best" one available in the system. Still, if needed to, any of them can be forced, given all their requirements are fulfilled, using the following new options of the 'phpunit' command: `--coverage-pcov`, `--coverage-xdebug` or `--coverage-phpdbg`.

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -31,7 +31,7 @@ jobs:
     # DB services you need for testing.
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -13,12 +13,15 @@ language: php
 
 # Installs the updated version of PostgreSQL and extra APT packages.
 addons:
-  postgresql: "10"
+  postgresql: "12"
+  apt:
+    packages:
+      - postgresql-12
+      - postgresql-client-12
 
 # Ensure DB and docker services are running.
 services:
   - mysql
-  - postgresql
   - docker
 
 # Cache Composer's and NPM's caches to speed up build times.
@@ -38,6 +41,11 @@ php:
 # This section sets up the environment variables for the build.
 env:
  global:
+# This line instructs moodle-plugin-ci the version of PostgreSQL being
+# used, because, for PG 11 and up, both the user and the port were
+# changed by Travis. With that variable, the tool will switch to
+# socketed connections instead of localhost ones.
+  - PGVER=12
 # This line determines which version branch of Moodle to test against.
   - MOODLE_BRANCH=MOODLE_311_STABLE
 # This matrix is used for testing against multiple databases.  So for

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/src/Installer/Database/PostgresDatabase.php
+++ b/src/Installer/Database/PostgresDatabase.php
@@ -22,6 +22,28 @@ class PostgresDatabase extends AbstractDatabase
 
     public function getCreateDatabaseCommand()
     {
+        // Travis changed the PostgreSQL package for version 11 and up so, instead of
+        // using the "postgres" user it now uses the "travis" one. And the port is
+        // 5433 instead of 5432. We use the existence of the PGVER environmental
+        // variable to decide which defaults to use.
+        //
+        // More yet, the connection via "localhost" (local net) now requires login and
+        // password, it used to be trust/peer auth mode (not requiring password). If we want to
+        // keep localhost (+ port) working, then we need to edit the  pg_hba.conf file
+        // to trust/peer the local connections and then restart the database.
+        //
+        // So, at the end, we are going to use socket connections (host = '')
+        // that is perfectly ok for Travis (non dockered database). Only if they
+        // haven't been configured another way manually (user, host, port).
+        if ($this->user === 'postgres' && getenv('PGVER') && is_numeric(getenv('PGVER')) && getenv('PGVER') >= 11) {
+            $this->user = 'travis';
+            if ($this->port === '') { // Only if the port is not set.
+                if ($this->host === 'localhost') {
+                    $this->host = ''; // Use sockets or we'll need to edit pg_hba.conf and restart the server. Only if not set.
+                    $this->port = '5433'; // We also need the port to find the correct socket file.
+                }
+            }
+        }
         $pass     = !empty($this->pass) ? 'env PGPASSWORD='.escapeshellarg($this->pass).' ' : '';
         $user     = escapeshellarg($this->user);
         $host     = escapeshellarg($this->host);


### PR DESCRIPTION
Trivial for GHA, just change of images to postgres:12, but...

Travis changed the PostgreSQL package for version 11 and up so, instead of
using the "postgres" user it now uses the "travis" one. And the port is
5433 instead of 5432. We use the existence of the PGVER environmental
variable to decide which defaults to use.

More yet, the connection via "localhost" (local net) now requires login and
password, it used to be trust/peer auth mode (not requiring password). If we want to
keep localhost (+ port) working, then we need to edit the  pg_hba.conf file
to trust/peer the local connections and then restart the database.

So, at the end, we are going to use socket connections (host = '')
that is perfectly ok for Travis (non dockered database). Only if they
haven't been configured another way manually (user, host, port).

Plus documenting the changes in a 2nd commit.