### PR TITLE
Bump GHA environments to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     # Avoid forks to perform this job.
     if: github.repository_owner == 'moodlehq'
     name: Create Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   selftest:
     name: CI test (make validate)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Check out repository code
@@ -28,7 +28,7 @@ jobs:
   citest:
     name: CI test
     needs: selftest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       postgres:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Updated all GHA scripts, templates and guides to use Ubuntu 22.04 (jammy). This change is not required yet, but integrations using old versions (Ubuntu 16.04, 18.04...) may face problems in the future because they are being deprecated.
+
 
 ## [3.4.0] - 2022-07-27
 ### Added

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -26,7 +26,7 @@ jobs:
   # when a job name is not provided
   test:
     # Virtual environment to use.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     # DB services you need for testing.
     services:

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     services:
       postgres:


### PR DESCRIPTION
Since some time ago, GH is warning us that the Ubuntu 18.04 environment is deprecated:

"The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead...."

Hence, we are bumping here, to be able to cerify if everything continues working ok.

The changes cover own scripts, templates and guides. All them now pointing to Ubuntu 22.04 (jammy).