### PR TITLE
Bump to actions/checkout@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP 7.3
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup PHP 7.3
       uses: shivammathur/setup-php@v2
@@ -60,7 +60,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup PHP ${{ matrix.php }}
       uses: shivammathur/setup-php@v2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+* Updated all uses of `actions/checkout` from `v2` (using node 12) to `v3` (using node 16), because [actions using node 12 are deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and will sop working in the future.
+* ACTION SUGGESTED: In order to avoid the node 12 deprecation warnings, update your workflows to use `actions/checkout@v3`.
 
 ## [3.4.1] - 2022-09-21
 ### Changed

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -84,7 +84,7 @@ jobs:
     steps:
       # Check out this repository code in ./plugin directory
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: plugin
 

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: plugin
 


### PR DESCRIPTION
Related to this deprecation of NodeJS 12 for GHA actions:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

We are moving all the references to actions/checkout@v2 by actions/checkout@v3, including:

- own moodle-plugin-ci workflows.
- template and docs.
- recommending the move in the changelog.

Fixes #187.