### PR TITLE
Switch to ncipollo/release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,23 +27,10 @@ jobs:
           php build/moodle-plugin-ci.phar list
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token does not need to be defined, it is available by default.
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          artifacts: build/moodle-plugin-ci.phar
+          artifactContentType: application/zip
           body: |
             Take a look at the [CHANGELOG](https://moodlehq.github.io/moodle-plugin-ci/CHANGELOG.html) for details about the release.
             Please follow [3.0 Upgrade guide](https://moodlehq.github.io/moodle-plugin-ci/UPGRADE-3.0.html) when upgrading from 2.x.
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/moodle-plugin-ci.phar
-          asset_name: moodle-plugin-ci.phar
-          asset_content_type: application/zip

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,8 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 
 ## [Unreleased]
 ### Changed
-* Updated all uses of `actions/checkout` from `v2` (using node 12) to `v3` (using node 16), because [actions using node 12 are deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and will sop working in the future.
+- Internal improvements to the release process.
+- Updated all uses of `actions/checkout` from `v2` (using node 12) to `v3` (using node 16), because [actions using node 12 are deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and will stop working in the future.
 * ACTION SUGGESTED: In order to avoid the node 12 deprecation warnings, update your workflows to use `actions/checkout@v3`.
 
 ## [3.4.1] - 2022-09-21


### PR DESCRIPTION
Old ones have been archived, so moving away from them. The picked one ([ncipollo/release-action](https://github.com/ncipollo/release-action))seems to be well supported, it has not many issues or prs pending and includes new stuff like node16 support.

I've created a couple of releases in my fork, and, apparently, everything has worked perfectly, with the release being created, the changes body working and the phar asset becoming available.

https://github.com/stronk7/moodle-plugin-ci/releases

Fixes #189.