### PR TITLE
Bump CI tests to use PHP 8.0 and PostgreSQL 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,13 @@ jobs:
       run: make validate
 
   citest:
-    name: CI test
+    name: Integration tests
     needs: selftest
     runs-on: ubuntu-22.04
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '7.4'
+          - php: '8.0'
             moodle-branch: 'master'
           - php: '7.4'
             moodle-branch: 'MOODLE_401_STABLE'
@@ -69,6 +69,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         extensions: pgsql, zip, gd, xmlrpc, soap
+        ini-values: max_input_vars=5000
         # We want to verify that xdebug works for coverage. Once we only support
         # Moodle 3.10/PHPUnit 8 and up, we can switch our tests to pcov too.
         coverage: xdebug

--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -1,11 +1,11 @@
 language: php
 
 addons:
-  postgresql: "12"
+  postgresql: "13"
   apt:
     packages:
-      - postgresql-12
-      - postgresql-client-12
+      - postgresql-13
+      - postgresql-client-13
 
 services:
   - mysql
@@ -23,7 +23,7 @@ php:
 
 env:
  global:
-  - PGVER=12
+  - PGVER=13
   - MOODLE_BRANCH=MOODLE_311_STABLE
  matrix:
   - DB=pgsql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 addons:
-  postgresql: "12"
+  postgresql: "13"
   apt:
     packages:
-      - postgresql-12
-      - postgresql-client-12
+      - postgresql-13
+      - postgresql-client-13
 
 services:
   - mysql
@@ -16,19 +16,16 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.npm
 
-php:
- - 7.4
-
 env:
   global:
-    - PGVER=12
+    - PGVER=13
     - IGNORE_PATHS=ignore
     - IGNORE_NAMES=ignore_name.php
     - MUSTACHE_IGNORE_NAMES=broken.mustache
     - DB=pgsql
-    - MOODLE_BRANCH=master
 
 before_install:
+  - echo 'max_input_vars=5000' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # We want to verify that xdebug works for coverage. Once we only support
   # Moodle 3.10/PHPUnit 8 and up, we can switch our tests to pcov too.
   # - phpenv config-rm xdebug.ini
@@ -49,8 +46,6 @@ install:
   - moodle-plugin-ci install -vvv
 
 script:
-  - make test-phpunit
-
   # This is basically "integration" testing.
   - moodle-plugin-ci phplint
   - moodle-plugin-ci phpcpd
@@ -67,14 +62,18 @@ script:
 
 jobs:
   include:
-    - stage: Tests
+    - stage: CI test (make validate)
       php: 7.3
       before_install: skip
       install:
         - make init
       script:
         - make validate
+
     - stage: Integration tests
+      if: env(MOODLE_BRANCH) IS present
+    - php: 8.0
+      env: MOODLE_BRANCH=master
     - php: 7.4
       env: MOODLE_BRANCH=MOODLE_401_STABLE
     - php: 7.4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Updated [gha.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/gha.dist.yml) and
+  [.travis.dist.yml](https://github.com/moodlehq/moodle-plugin-ci/blob/master/.travis.dist.yml)
+  (and documentation) to fulfil [Moodle 4.2 new requirements](https://tracker.moodle.org/browse/MDL-74905).
+- ACTION REQUIRED: Review existing integrations running tests against master (4.2dev). There are a few Moodle 4.2 new requirements:
+  - PHP 8.0 is required (instead of 7.4).
+  - PostgreSQL 13 is required (instead of 12).
+  - MariaDB 10.6 is required (instead of 10.4).
+  - MySQL 8 is required (instead of 5.7).
 
 ## [3.4.2] - 2022-10-18
 ### Changed

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -31,7 +31,7 @@ jobs:
     # DB services you need for testing.
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -13,11 +13,11 @@ language: php
 
 # Installs the updated version of PostgreSQL and extra APT packages.
 addons:
-  postgresql: "12"
+  postgresql: "13"
   apt:
     packages:
-      - postgresql-12
-      - postgresql-client-12
+      - postgresql-13
+      - postgresql-client-13
 
 # Ensure DB and docker services are running.
 services:
@@ -45,7 +45,7 @@ env:
 # used, because, for PG 11 and up, both the user and the port were
 # changed by Travis. With that variable, the tool will switch to
 # socketed connections instead of localhost ones.
-  - PGVER=12
+  - PGVER=13
 # This line determines which version branch of Moodle to test against.
   - MOODLE_BRANCH=MOODLE_311_STABLE
 # This matrix is used for testing against multiple databases.  So for

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'


### PR DESCRIPTION
Note we also have applied a couple of extra changes:

- Rename the both travis and gha job names to match.
- Refactor travis noticeably to better separarte validate
  and integration tests, avoiding the "phantom" job that
  was caused by the matrix behaviour.