### PR TITLE
Bump to php-coveralls/php-coveralls v2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Updated to `php-coveralls/php-coveralls` v2 for uploading coverage results to [Coveralls](https://coveralls.io) with the `coveralls-upload` command.
+- ACTION REQUIRED: Review any use of the `coveralls-upload` command in GHA and ensure that `COVERALLS_REPO_TOKEN` is set in the environment. See [Coveralls integration](https://github.com/moodlehq/moodle-plugin-ci/blob/master/docs/CodeCoverage.md#coveralls-integration) for more information.
 
 ## [3.4.4] - 2023-01-20
 ### Changed

--- a/docs/CodeCoverage.md
+++ b/docs/CodeCoverage.md
@@ -10,7 +10,7 @@ Code coverage will now automatically fallback between `pcov` => `xdebug` => `php
 
 The way you generate code coverage is to use one of the coverage options on the `phpunit` command.  The currently
 available options are `--coverage-text` and `--coverage-clover`.  The easiest way to start generating code coverage
-is to use the text option as that gets printed in the Travis CI logs.  Example:
+is to use the text option as that gets printed in the CI logs.  Example:
 
 ```yaml
 script:
@@ -42,9 +42,24 @@ If you would like to use Coveralls, then go to https://coveralls.io and login wi
 need to authorize access to your public repositories.  Once you have done that, navigate to your
 [REPOS](https://coveralls.io/repos) listing and use the _ADD REPOS_ button in the upper right to turn on your project.
 
-Then, you need to make the following changes to your plugin's `.travis.yml` file.  You need to tell the `phpunit`
-command to generate clover coverage and then use the `coveralls-upload` command to actually upload the coverage.
-Example:
+Then, you need to instruct to your favourite CI tool, so the `phpunit` command generates the clover coverage file and, then, use the `coveralls-upload` command to actually upload the coverage.
+
+Some examples follow:
+
+#### GitHub Actions
+
+```yaml
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: |
+          moodle-plugin-ci phpunit --coverage-clover
+          moodle-plugin-ci coveralls-upload
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+Note that, instead of the automatically generated for every run `${{ secrets.GITHUB_TOKEN }}` token you can use any other GitHub token (PAT...) with the correct perms or, also, the token that Coveralls offers to you for every repository. Just it's easier to use the automatic GitHub one, because that way you don't need to create tokens or secrets manually and maintain them.
+
+#### Travis
 
 ```yaml
 script:

--- a/src/Command/CoverallsUploadCommand.php
+++ b/src/Command/CoverallsUploadCommand.php
@@ -51,13 +51,17 @@ class CoverallsUploadCommand extends AbstractPluginCommand
             return 0;
         }
 
-        $process = new Process('composer create-project -n --no-dev --prefer-dist satooshi/php-coveralls _php_coveralls ^1', $this->plugin->directory);
-        $this->execute->mustRun($process);
-
         $filesystem = new Filesystem();
+
+        // Only if it has not been installed before.
+        if (!$filesystem->exists($this->plugin->directory.'/coveralls')) {
+            $process = new Process('composer create-project -n --no-dev --prefer-dist php-coveralls/php-coveralls coveralls ^2', $this->plugin->directory);
+            $this->execute->mustRun($process);
+        }
+
         $filesystem->copy($coverage, $this->plugin->directory.'/build/logs/clover.xml');
 
-        $process = $this->execute->passThrough('_php_coveralls/bin/coveralls -v', $this->plugin->directory);
+        $process = $this->execute->passThrough('coveralls/bin/php-coveralls -v', $this->plugin->directory);
 
         return $process->isSuccessful() ? 0 : 1;
     }


### PR DESCRIPTION
The old satooshi/php-coverall v1 has stopper working recently, so bumping to v2.

Also, make the installation of it optional, better for local environments where it can be already installed.

Fixes #59