### PR TITLE
Update tools to current ones

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_ci",
-        "version": "1.0.15",
+        "version": "1.0.16",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_ci.git",
           "type": "git",
-          "reference": "v1.0.15"
+          "reference": "v1.0.16"
         }
       }
     },
@@ -52,11 +52,11 @@
       "type": "package",
       "package": {
         "name": "moodlehq/moodle-local_moodlecheck",
-        "version": "1.1.2",
+        "version": "1.1.3",
         "source": {
           "url": "https://github.com/moodlehq/moodle-local_moodlecheck.git",
           "type": "git",
-          "reference": "v1.1.2"
+          "reference": "v1.1.3"
         }
       }
     }
@@ -64,8 +64,8 @@
   "require": {
     "php": ">=7.0.8",
     "moodlehq/moodle-cs": "^3.2.3",
-    "moodlehq/moodle-local_ci": "^1.0.15",
-    "moodlehq/moodle-local_moodlecheck": "^1.1.2",
+    "moodlehq/moodle-local_ci": "^1.0.16",
+    "moodlehq/moodle-local_moodlecheck": "^1.1.3",
     "sebastian/phpcpd": "^3.0",
     "sebastian/version": "^2.0.1",
     "phpmd/phpmd": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0dbc565ab7b31000c4e3027cfc16afb0",
+    "content-hash": "ca42a0d194305a08919b4d59efcc5f9d",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -406,21 +406,21 @@
         },
         {
             "name": "moodlehq/moodle-local_ci",
-            "version": "1.0.15",
+            "version": "1.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_ci.git",
-                "reference": "v1.0.15"
+                "reference": "v1.0.16"
             },
             "type": "library"
         },
         {
             "name": "moodlehq/moodle-local_moodlecheck",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodlehq/moodle-local_moodlecheck.git",
-                "reference": "v1.1.2"
+                "reference": "v1.1.3"
             },
             "type": "library"
         },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Updated project dependencies to current [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) versions.
+
 ### Fixed
 - Updated to `php-coveralls/php-coveralls` v2 for uploading coverage results to [Coveralls](https://coveralls.io) with the `coveralls-upload` command.
 - ACTION REQUIRED: Review any use of the `coveralls-upload` command in GHA and ensure that `COVERALLS_REPO_TOKEN` is set in the environment. See [Coveralls integration](https://github.com/moodlehq/moodle-plugin-ci/blob/master/docs/CodeCoverage.md#coveralls-integration) for more information.


### PR DESCRIPTION
- local_ci
- local_moodlecheck

Not much to say, just updating before making a quick release. The updates will solve a few composer warnings, espcially when installing the local_ci requirements, because there was a wrongly named file leading to this warning:

```
Class MoodleHQ\MoodleCS\moodle\Tests\MoodleCsStandardTest located in ./vendor/moodlehq/moodle-cs/moodle/Tests/MoodleStandardTest.php does not comply with psr-4 autoloading standard. Skipping.
```

Not the end of the world, because that Test file is not used (comes from moodle-cs), but towards a clean composer install.

Ciao :-)