### PR TITLE
Support PHPCompatibility testVersion config

### DIFF
--- a/src/Command/CodeCheckerCommand.php
+++ b/src/Command/CodeCheckerCommand.php
@@ -39,7 +39,9 @@ class CodeCheckerCommand extends AbstractPluginCommand
             ->setDescription('Run Moodle CodeSniffer standard on a plugin')
             ->addOption('standard', 's', InputOption::VALUE_REQUIRED, 'The name or path of the coding standard to use', 'moodle')
             ->addOption('max-warnings', null, InputOption::VALUE_REQUIRED,
-                'Number of warnings to trigger nonzero exit code - default: -1', -1);
+                'Number of warnings to trigger nonzero exit code - default: -1', -1)
+            ->addOption('test-version', null, InputOption::VALUE_REQUIRED,
+                'Version or range of version to test with PHPCompatibility', 0);
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -80,6 +82,12 @@ class CodeCheckerCommand extends AbstractPluginCommand
             // If we are using the max-warnings option, we need the summary report somewhere to get
             // the total number of errors and warnings from there.
             $cmd[] = '--report-json=' . $this->tempFile;
+        }
+
+        // Show PHPCompatibility backward-compatibility errors for a version or version range.
+        $testVersion = $input->getOption('test-version');
+        if (!empty($testVersion)) {
+            array_push($cmd, '--runtime-set', 'testVersion', $testVersion);
         }
 
         // Add the files to process.

--- a/tests/Command/CodeCheckerCommandTest.php
+++ b/tests/Command/CodeCheckerCommandTest.php
@@ -34,7 +34,7 @@ class CodeCheckerCommandTest extends MoodleTestCase
         $this->fs->dumpFile($this->pluginDir . '/.moodle-plugin-ci.yml', Yaml::dump($config));
     }
 
-    protected function executeCommand($pluginDir = null, $maxWarnings = -1): CommandTester
+    protected function executeCommand($pluginDir = null, $maxWarnings = -1, $testVersion = null): CommandTester
     {
         if ($pluginDir === null) {
             $pluginDir = $this->pluginDir;
@@ -49,6 +49,10 @@ class CodeCheckerCommandTest extends MoodleTestCase
         $options = ['plugin' => $pluginDir];
         if ($maxWarnings >= 0) {
             $options['--max-warnings'] = $maxWarnings;
+        }
+
+        if (null !== $testVersion) {
+            $options['--test-version'] = $testVersion;
         }
 
         $commandTester = new CommandTester($application->find('codechecker'));
@@ -143,6 +147,68 @@ EOT;
         // Allowing 3 warnings, it passes.
         $commandTester = $this->executeCommand($this->pluginDir, 3);
         $this->assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testExecuteWithTestVersion()
+    {
+        // Let's add a file with some new and deprecated stuff, and verify that the test-version option affects to the outcome.
+        $content = <<<'EOT'
+<?php // phpcs:disable moodle
+mb_str_split();                       // New in PHP 7.4.
+ini_get('allow_url_include');         // Deprecated in PHP 7.4.
+ldap_count_references();              // New in PHP 8.0.
+pg_errormessage();                    // Deprecated in PHP 8.0.
+$fb = new ReflectionFiber();          // New in PHP 8.1.
+ini_get('auto_detect_line_endings');  // Deprecated in PHP 8.1.
+openssl_cipher_key_length();          // New in PHP 8.2.
+utf8_encode();                        // Deprecated in PHP 8.2.
+
+EOT;
+        $this->fs->dumpFile($this->pluginDir . '/test_versions.php', $content);
+
+        // By default, without specify test-version, only reports deprecation warnings and returns 0.
+        $commandTester = $this->executeCommand($this->pluginDir, -1, null);
+        $output        = $commandTester->getDisplay();
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES/', $output);
+
+        // With test-version 7.4, reports 2 new errors and <= 7.4 specific warnings and returns 1.
+        $commandTester = $this->executeCommand($this->pluginDir, -1, '7.4');
+        $output        = $commandTester->getDisplay();
+        $this->assertSame(1, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/FOUND 2 ERRORS AND 1 WARNING AFFECTING 3 LINES/', $output);
+
+        // With test-version 8.0, reports 1 new errors and <= 8.0 specific warnings and returns 1.
+        $commandTester = $this->executeCommand($this->pluginDir, -1, '8.0');
+        $output        = $commandTester->getDisplay();
+        $this->assertSame(1, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/FOUND 1 ERROR AND 2 WARNINGS AFFECTING 3 LINES/', $output);
+
+        // With test-version 8.1, reports 0 new errors and <= 8.1 specific warnings and returns 0.
+        $commandTester = $this->executeCommand($this->pluginDir, -1, '8.1');
+        $output        = $commandTester->getDisplay();
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES/', $output);
+
+        // With test-version 7.4-8.0, reports 2 new errors and <= 8.0 specific warnings and returns 1.
+        $commandTester = $this->executeCommand($this->pluginDir, -1, '7.4-8.0');
+        $output        = $commandTester->getDisplay();
+        $this->assertSame(1, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/FOUND 2 ERRORS AND 2 WARNINGS AFFECTING 4 LINES/', $output);
+
+        // With test-version 7.4-8.1, reports 2 new errors and <= 8.1 specific warnings and returns 1.
+        $commandTester = $this->executeCommand($this->pluginDir, -1, '7.4-8.1');
+        $output        = $commandTester->getDisplay();
+        $this->assertSame(1, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/FOUND 2 ERRORS AND 3 WARNINGS AFFECTING 5 LINES/', $output);
+
+        // With test-version 7.4- (open range), reports 2 new errors and <= 8.2 specific warnings and returns 1.
+        // (note that it should be 1 more warning and 1 more error, but the PHPCompatibility sniffs are not
+        // still ready for many of the PHP 8.2 changes. We'll amend this test when they are ready).
+        $commandTester = $this->executeCommand($this->pluginDir, -1, '7.4-');
+        $output        = $commandTester->getDisplay();
+        $this->assertSame(1, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/FOUND 2 ERRORS AND 3 WARNINGS AFFECTING 5 LINES/', $output);
     }
 
     public function testExecuteNoFiles()


### PR DESCRIPTION
After reading through the PHPCompatibility documentation, it seems that without setting the testVersion value, we are not getting the errors for backward-incompatible functionality. Specifically, functions, constants, syntaxes and classes that were added in newer versions were not being reported. It was only reporting forward-incompatible changes (functionality that had been removed in newer versions of PHP).

Fixes #205 