### PR TITLE
Bump all travis files and docs to require Ubuntu 20.04

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: focal
+
 addons:
   postgresql: "13"
   apt:
@@ -17,9 +19,9 @@ cache:
     - $HOME/.npm
 
 php:
- - 7.3
  - 7.4
  - 8.0
+ - 8.1
 
 env:
  global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: focal
+
 addons:
   postgresql: "13"
   apt:
@@ -54,7 +56,7 @@ script:
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache
-  - moodle-plugin-ci grunt || [ "$MOODLE_BRANCH" == 'MOODLE_38_STABLE' ]
+  - moodle-plugin-ci grunt || [[ "$MOODLE_BRANCH" =~ MOODLE_3[0-9]+_STABLE ]] # Fixtures only compatible with Moodle >= 4.0
   - moodle-plugin-ci phpdoc
   - moodle-plugin-ci phpunit --verbose --coverage-text --fail-on-warning
   - moodle-plugin-ci behat --profile default
@@ -63,7 +65,7 @@ script:
 jobs:
   include:
     - stage: CI test (make validate)
-      php: 7.3
+      php: 7.4
       before_install: skip
       install:
         - make init

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Modified the Travis templates and docs to point that, since [MDL-75012](https://tracker.moodle.org/browse/MDL-75012) (core update to Node 18), Ubuntu Focal 20.04 is the minimum required by runs.
 
 ## [3.4.7] - 2023-03-04
 ### Changed

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -11,6 +11,9 @@ see [Travis CI's documentation](http://docs.travis-ci.com/user/getting-started/)
 # This is the language of our project.
 language: php
 
+# Note that focal (20.04) is the minimum because Node 18 requires it.
+dist: focal
+
 # Installs the updated version of PostgreSQL and extra APT packages.
 addons:
   postgresql: "13"
@@ -34,9 +37,9 @@ cache:
 # listed here will create a separate build and run the tests against that
 # version of PHP.
 php:
- - 7.3
  - 7.4
  - 8.0
+ - 8.1
 
 # This section sets up the environment variables for the build.
 env:

--- a/src/Installer/Database/PostgresDatabase.php
+++ b/src/Installer/Database/PostgresDatabase.php
@@ -41,6 +41,10 @@ class PostgresDatabase extends AbstractDatabase
                 if ($this->host === 'localhost') {
                     $this->host = ''; // Use sockets or we'll need to edit pg_hba.conf and restart the server. Only if not set.
                     $this->port = '5433'; // We also need the port to find the correct socket file.
+                    // Travis did it again, for PostgreSQL 13, they are back to port 5432. We need that to find the socket.
+                    if ((int) getenv('PGVER') === 13) {
+                        $this->port = '5432'; // We also need the port to find the correct socket file.
+                    }
                 }
             }
         }


### PR DESCRIPTION
NodeJS 18 requires GLIBC 2.28, that only comes in 18.10 (non LTS) and 20.04 (focal) Ubuntu versions. Change all the Travis references to point to that, because, by default, it uses denial older version.

Also bump the "make validate" self tests and the Travis dist files and docs to use php74 as minimum,,
because focal on Travis doesn't support php73 any more.

Finally, it seems that, for focal, they have changed again the PostgreSQL port to be 5432 (it was 5433 for PostgreSQL 11 and 12). So let's specify it again. Ping, pong!

Side note: We have disabled grunt for all Moodle 3.x branches because the Node 18 issue came with unexpected changes to .map files and now they are failing. [MDL-77527](https://tracker.moodle.org/browse/MDL-77527) has been created to fix that regression of [MDL-75012](https://tracker.moodle.org/browse/MDL-75012). Once it's fixed, we'll enable back grunt for 39 and 311.