### PR TITLE
Automatically add the version changelog section to the release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,20 @@ jobs:
           make build
           php build/moodle-plugin-ci.phar list
 
+      - name: Extract release notes from changelog
+        id: extract-release-notes
+        uses: yashanand1910/standard-release-notes@v1.3.0
+        with:
+          changelog_path: docs/CHANGELOG.md
+          version: ${{ github.ref }}
+
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
           artifacts: build/moodle-plugin-ci.phar
           artifactContentType: application/zip
           body: |
-            Take a look at the [CHANGELOG](https://moodlehq.github.io/moodle-plugin-ci/CHANGELOG.html) for details about the release.
+            ${{ steps.extract-release-notes.outputs.release_notes }}
+            #
+            Take a look at the [CHANGELOG](https://moodlehq.github.io/moodle-plugin-ci/CHANGELOG.html) for details about other releases.
             Please follow [3.0 Upgrade guide](https://moodlehq.github.io/moodle-plugin-ci/UPGRADE-3.0.html) when upgrading from 2.x.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Improved release process: Now every version changelog (this file) is automatically added to the release notes.
 
 ## [3.4.8] - 2023-03-06
 ### Changed


### PR DESCRIPTION
Using the yashanand1910/standard-release-notes action, now we are extracting the matching version from the docs/CHANGELOG.md file and adding it to the release notes.

This is an example of a released version (99.99.99) and how the release info looks:

https://github.com/stronk7/moodle-plugin-ci/releases/tag/99.99.99

And, this an example of a failed run because the released version (99.99.98) does not have any entry in the changelog:

https://github.com/stronk7/moodle-plugin-ci/actions/runs/4347058191

Ciao :-)