### PR TITLE
CI Example Updates

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -34,9 +34,10 @@ env:
 before_install:
   - if [[ ${TRAVIS_PHP_VERSION:0:1} -gt 7 ]]; then pecl install xmlrpc-beta; fi
   - echo 'max_input_vars=5000' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # Don't disable xdebug if you want to get it used for code coverage.
+  # We remove xdebug by default for performance, because we're not checking code coverage.
+  # If you want to use xdebug for code coverage, remove this line.
   - phpenv config-rm xdebug.ini
-  # Alternative (for Moodle 3.10 and up) is to use pcov. It can be installed using:
+  # To use pcov for code coverage on Moodle 3.10 and up, install it using:
   # - pecl install pcov
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3

--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -50,7 +50,7 @@ script:
   - moodle-plugin-ci phplint
   - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
-  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci phpcs
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -149,7 +149,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 0
+        run: moodle-plugin-ci phpcs --max-warnings 0
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -95,7 +95,8 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
           ini-values: max_input_vars=5000
-          # none to use phpdbg fallback. Specify pcov (Moodle 3.10 and up) or xdebug to use them instead.
+          # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
+          # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
           coverage: none
 
       # Install this project into a directory called "ci", updating PATH and

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -89,8 +89,11 @@ before_install:
 - if [[ ${TRAVIS_PHP_VERSION:0:1} -gt 7 ]]; then pecl install xmlrpc-beta; fi
 # Setup a good default max_input_vars value for all runs.
 - echo 'max_input_vars=5000' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-# This disables XDebug which should speed up the build.
+# We remove xdebug by default for performance, because we're not checking code coverage.
+# If you want to use xdebug for code coverage, remove this line.
   - phpenv config-rm xdebug.ini
+# To use pcov for code coverage on Moodle 3.10 and up, install it using:
+# - pecl install pcov
 # Currently we are inside of the clone of your repository.  We move up two
 # directories to build the project.
   - cd ../..

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -134,7 +134,7 @@ script:
 # conforms to the Moodle coding standards.  It is highly recommended
 # that you keep this step.
 # To fail on warnings use --max-warnings 0
-  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci phpcs
 # This step runs Moodle PHPDoc checker on your plugin.
   - moodle-plugin-ci phpdoc
 # This step runs some light validation on the plugin file structure

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -46,7 +46,8 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
           ini-values: max_input_vars=5000
-          # none to use phpdbg fallback. Specify pcov (Moodle 3.10 and up) or xdebug to use them instead.
+          # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
+          # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
           coverage: none
 
       - name: Initialise moodle-plugin-ci

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 0
+        run: moodle-plugin-ci phpcs --max-warnings 0
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}


### PR DESCRIPTION
These comment changes include the additional context that I was previously missing to understand how code coverage works in moodle-plugin-ci.

Also, switches the examples to use `phpcs` instead of the `codechecker` alias.

Fixes #211 (deprecating phpdbg should probably be a separate issue)