### PR TITLE
When trying to use this tool on anything other than Travis it is hard…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
+## [Unreleased]
+### Added
+- Add support for the following optional env variables, that will be used on installation, getting precedence over the corresponding existing option:
+    - `DB_USER`: To specify the database username (alternative to `--db-user`)
+    - `DB_PASS`: To specify the database password (alternative to `--db-pass`)
+    - `DB_NAME`: To specify the database name (alternative to `--db-name`)
+    - `DB_HOST`: To specify the database host (alternative to `--db-host`)
+    - `DB_PORT`: To specify the database port (alternative to `--db-port`)
+
+    Note that these new env variables behave exactly the same than the existing (and often used) `DB` one, that is also a priority alternative to `--db-type` on install.
+
 ## [4.1.0] - 2023-05-29
 ### Added
 - Add the `--testdox` option to the `phpunit` command.

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -120,6 +120,10 @@ jobs:
       #   MUSTACHE_IGNORE_NAMES: 'broken.mustache'
       #   CODECHECKER_IGNORE_PATHS: 'ignoreme'
       #   CODECHECKER_IGNORE_NAMES: 'ignoreme_name.php'
+      #
+      # Other env vars are available for install, namely:
+      #   - DB_USER / DB_PASS / DB_NAME / DB_HOST / DB_PORT: used
+      #     by install to feed the corresponding --db-xxxx options.
       - name: Install moodle-plugin-ci
         run: |
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -55,7 +55,9 @@ env:
 # each version of PHP being tested, one build will be created for each
 # database listed here.  EG: for PHP 7.4, one build will be created
 # using PHP 7.4 and pgsql.  In addition, another build will be created
-# using PHP 7.4 and mysqli.
+# using PHP 7.4 and mysqli. Also, note that DB_USER / DB_PASS / DB_NAME
+# / DB_HOST / DB_PORT env vars can be used by install to feed the
+# corresponding --db-xxxx options.
  matrix:
   - DB=pgsql
   - DB=mysqli

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -67,6 +67,13 @@ class InstallCommand extends Command
             $plugin = getenv('CI_BUILD_DIR') !== false ? getenv('CI_BUILD_DIR') : null;
         }
 
+        // Add more options mapped to environment variables.
+        $dbUser = getenv('DB_USER') !== false ? getenv('DB_USER') : null;
+        $dbPass = getenv('DB_PASS') !== false ? getenv('DB_PASS') : '';
+        $dbName = getenv('DB_NAME') !== false ? getenv('DB_NAME') : 'moodle';
+        $dbHost = getenv('DB_HOST') !== false ? getenv('DB_HOST') : 'localhost';
+        $dbPort = getenv('DB_PORT') !== false ? getenv('DB_PORT') : '';
+
         $this->setName('install')
             ->setDescription('Install everything required for CI testing')
             ->addOption('moodle', null, InputOption::VALUE_REQUIRED, 'Clone Moodle to this directory', 'moodle')
@@ -75,11 +82,11 @@ class InstallCommand extends Command
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Moodle git branch to clone, EG: MOODLE_29_STABLE', $branch)
             ->addOption('plugin', null, InputOption::VALUE_REQUIRED, 'Path to Moodle plugin', $plugin)
             ->addOption('db-type', null, InputOption::VALUE_REQUIRED, 'Database type, mysqli, pgsql or mariadb', $type)
-            ->addOption('db-user', null, InputOption::VALUE_REQUIRED, 'Database user')
-            ->addOption('db-pass', null, InputOption::VALUE_REQUIRED, 'Database pass', '')
-            ->addOption('db-name', null, InputOption::VALUE_REQUIRED, 'Database name', 'moodle')
-            ->addOption('db-host', null, InputOption::VALUE_REQUIRED, 'Database host', 'localhost')
-            ->addOption('db-port', null, InputOption::VALUE_REQUIRED, 'Database port', '')
+            ->addOption('db-user', null, InputOption::VALUE_REQUIRED, 'Database user', $dbUser)
+            ->addOption('db-pass', null, InputOption::VALUE_REQUIRED, 'Database pass', $dbPass)
+            ->addOption('db-name', null, InputOption::VALUE_REQUIRED, 'Database name', $dbName)
+            ->addOption('db-host', null, InputOption::VALUE_REQUIRED, 'Database host', $dbHost)
+            ->addOption('db-port', null, InputOption::VALUE_REQUIRED, 'Database port', $dbPort)
             ->addOption('not-paths', null, InputOption::VALUE_REQUIRED, 'CSV of file paths to exclude', $paths)
             ->addOption('not-names', null, InputOption::VALUE_REQUIRED, 'CSV of file names to exclude', $names)
             ->addOption('extra-plugins', null, InputOption::VALUE_REQUIRED, 'Directory of extra plugins to install', $extra)


### PR DESCRIPTION
…er to make ci script look lean because so many options have to be crammed in the install command line.

It would be most useful to have more install options mapped to ENV variables.

Fixes #217