### PR TITLE
Add --max-warnings option to the PHPDoc command

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -50,11 +50,11 @@ script:
   - moodle-plugin-ci phplint
   - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
-  - moodle-plugin-ci phpcs
+  - moodle-plugin-ci phpcs --max-warnings 0
+  - moodle-plugin-ci phpdoc --max-warnings 0
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
-  - moodle-plugin-ci phpdoc --fail-on-warning
-  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci phpunit --fail-on-warning
   - moodle-plugin-ci behat

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,9 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 
 ## [Unreleased]
 ### Added
-- Add the `--testdox` option within the `phpunit` command.
+- Add the `--testdox` option to the `phpunit` command.
+- Add the `--max-warnings` option to the `phpdoc` command, so it behaves the same than the `phpcs` command. Note that this modifies current behaviour (see next point) and plugins with only warnings won't be failing any more.
+- ACTION SUGGESTED: In order to keep the previous behaviour, it's recommended to use the new `--max-warnings 0` (or any other number) option to specify the warnings threshold.
 
 ### Changed
 - Updated project dependencies to current [moodle-cs](https://github.com/moodlehq/moodle-cs), [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) versions. Also, to various internal / development tools.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1666,7 +1666,7 @@ Run Moodle PHPDoc Checker on a plugin
 
 ### Usage
 
-* `phpdoc [-m|--moodle MOODLE] [--] <plugin>`
+* `phpdoc [-m|--moodle MOODLE] [--max-warnings MAX-WARNINGS] [--] <plugin>`
 
 Run Moodle PHPDoc Checker on a plugin
 
@@ -1691,6 +1691,16 @@ Path to Moodle
 * Is multiple: no
 * Is negatable: no
 * Default: `'.'`
+
+#### `--max-warnings`
+
+Number of warnings to trigger nonzero exit code - default: -1
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `-1`
 
 #### `--help|-h`
 

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -150,7 +150,7 @@ jobs:
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci phpdoc
+        run: moodle-plugin-ci phpdoc --max-warnings 0
 
       - name: Validating
         if: ${{ always() }}

--- a/docs/Help.md
+++ b/docs/Help.md
@@ -45,7 +45,7 @@ you keep this step.  To fail on warnings use `--max-warnings 0`
 
 **moodle-plugin-ci phpdoc**
 
-This step runs Moodle PHPDoc checker on your plugin.
+This step runs Moodle PHPDoc checker on your plugin. To fail on warnings use `--max-warnings 0`
 
 **moodle-plugin-ci validate**
 

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -136,6 +136,7 @@ script:
 # To fail on warnings use --max-warnings 0
   - moodle-plugin-ci phpcs
 # This step runs Moodle PHPDoc checker on your plugin.
+# To fail on warnings use --max-warnings 0
   - moodle-plugin-ci phpdoc
 # This step runs some light validation on the plugin file structure
 # and code.  Validation can be plugin specific.

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci phpdoc
+        run: moodle-plugin-ci phpdoc --max-warnings 0
 
       - name: Validating
         if: ${{ always() }}

--- a/src/Command/PHPDocCommand.php
+++ b/src/Command/PHPDocCommand.php
@@ -14,6 +14,7 @@ namespace MoodlePluginCI\Command;
 
 use MoodlePluginCI\Bridge\MoodlePlugin;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -30,7 +31,9 @@ class PHPDocCommand extends AbstractMoodleCommand
         parent::configure();
 
         $this->setName('phpdoc')
-            ->setDescription('Run Moodle PHPDoc Checker on a plugin');
+            ->setDescription('Run Moodle PHPDoc Checker on a plugin')
+            ->addOption('max-warnings', null, InputOption::VALUE_REQUIRED,
+                'Number of warnings to trigger nonzero exit code - default: -1', -1);
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -74,9 +77,19 @@ class PHPDocCommand extends AbstractMoodleCommand
         }
 
         // moodlecheck.php does not return valid exit status,
-        // We have to parse output to see if there are errors.
-        $results = $process->getOutput();
+        // We have to parse output to see if there are errors and/or warnings.
+        $results        = $process->getOutput();
+        $totalProblems  = (int) preg_match_all('~^\\s+Line~m', $results);
+        $totalWarnings  = (int) preg_match_all('~\(warning\)$~m', $results);
+        $totalErrors    = $totalProblems - $totalWarnings;
+        $pseudoExitCode = ($totalErrors > 0) ? 1 : 0; // Calculate exit code based on # errors by default.
 
-        return (preg_match('/\s+Line/', $results)) ? 1 : 0;
+        // If we aren't using the max-warnings option, (pseudo) process exit code is enough for us.
+        if ($input->getOption('max-warnings') < 0) {
+            return $pseudoExitCode;
+        }
+
+        // With errors or warnings over the max-warnings threshold, fail the command.
+        return ($totalErrors > 0 || ($totalWarnings > $input->getOption('max-warnings'))) ? 1 : 0;
     }
 }

--- a/tests/Command/PHPDocCommandTest.php
+++ b/tests/Command/PHPDocCommandTest.php
@@ -1,0 +1,142 @@
+<?php
+
+// This file is part of the Moodle Plugin CI package.
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace MoodlePluginCI\Tests\Command;
+
+use MoodlePluginCI\Bridge\MoodleConfig;
+use MoodlePluginCI\Command\PHPDocCommand;
+use MoodlePluginCI\Installer\Database\MySQLDatabase;
+use MoodlePluginCI\Tests\Fake\Bridge\DummyMoodlePHPDoc;
+use MoodlePluginCI\Tests\Fake\Bridge\DummyMoodlePlugin;
+use MoodlePluginCI\Tests\Fake\Process\DummyExecute;
+use MoodlePluginCI\Tests\MoodleTestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Unit tests for PHPDocCommand.
+ *
+ * @copyright  2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class PHPDocCommandTest extends MoodleTestCase
+{
+    protected function executeCommand($pluginDir = null, $maxWarnings = -1, $mockOutput = ''): CommandTester
+    {
+        if ($pluginDir === null) {
+            $pluginDir = $this->pluginDir;
+        }
+
+        $command                        = new PHPDocCommand();
+        $command->moodle                = new DummyMoodlePHPDoc($this->moodleDir);
+        $command->plugin                = new DummyMoodlePlugin($pluginDir);
+        $command->execute               = new DummyExecute(); // Mocked execution.
+        $command->execute->returnOutput = $mockOutput;          // Mocked output.
+
+        // Note: we leave this here as reference for any other command test needing a config.php file,
+        // but it's not needed for this unit tess that is using a mocked execute() method.
+        // Create a basic config.php file. This command requires it.
+        // $config         = new MoodleConfig();
+        // $configContents = $config->createContents(new MySQLDatabase(), '/path/to/moodledata');
+        // $config->dump($this->moodleDir . DIRECTORY_SEPARATOR . 'config.php', $configContents);
+
+        $application = new Application();
+        $application->add($command);
+
+        $options = ['plugin' => $pluginDir];
+        if ($maxWarnings >= 0) {
+            $options['--max-warnings'] = $maxWarnings;
+        }
+
+        $commandTester = new CommandTester($application->find('phpdoc'));
+        $commandTester->execute($options);
+
+        return $commandTester;
+    }
+
+    public function testExecute()
+    {
+        $commandTester = $this->executeCommand();
+        $this->assertSame(0, $commandTester->getStatusCode());
+
+        // Verify various parts of the output.
+        $output = $commandTester->getDisplay();
+
+        // Also verify display info is correct.
+        $this->assertMatchesRegularExpression('/RUN  Moodle PHPDoc Checker on local_ci/', $output);
+    }
+
+    public function testExecuteFail()
+    {
+        $mockOutput    = '  Line 12: Some error happened';
+        $commandTester = $this->executeCommand($this->pluginDir, -1, $mockOutput);
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        // Verify various parts of the output.
+        // Note: Because this is a mocked process, with mocked output, we cannot inspect the command output
+        // as we do in other tests. Only the title is available.
+        // Some day all the mocks should be refactored to allow this.
+        // $output = $commandTester->getDisplay();
+        // $this->assertMatchesRegularExpression('xxxxxxx/', $output);                  // Progress.
+
+        // Also verify display info is correct.
+        $this->assertMatchesRegularExpression('/RUN  Moodle PHPDoc Checker/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithWarningsAndThreshold()
+    {
+        // Let's add a file with 2 warnings, and verify how the max-warnings affects the outcome.
+        $mockOutput = <<<'EOT'
+    Line 2: Empty line found after PHP open tag (warning)
+    Line 12: Function someclass::somefunc is not documented (warning)
+
+EOT;
+        // By default it passes.
+        $commandTester = $this->executeCommand($this->pluginDir, -1, $mockOutput);
+        $this->assertSame(0, $commandTester->getStatusCode());
+
+        // Allowing 0 warning, it fails.
+        $commandTester = $this->executeCommand($this->pluginDir, 0, $mockOutput);
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        // Allowing 1 warning, it fails.
+        $commandTester = $this->executeCommand($this->pluginDir, 1, $mockOutput);
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        // Allowing 2 warnings, it passes.
+        $commandTester = $this->executeCommand($this->pluginDir, 2, $mockOutput);
+        $this->assertSame(0, $commandTester->getStatusCode());
+
+        // Allowing 3 warnings, it passes.
+        $commandTester = $this->executeCommand($this->pluginDir, 3, $mockOutput);
+        $this->assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testExecuteNoFiles()
+    {
+        // Just random directory with no PHP files.
+        $commandTester = $this->executeCommand($this->pluginDir . '/tests/behat');
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/No relevant files found to process, free pass!/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteNoPlugin()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->executeCommand('/path/to/no/plugin');
+    }
+}

--- a/tests/Fake/Bridge/DummyMoodlePHPDoc.php
+++ b/tests/Fake/Bridge/DummyMoodlePHPDoc.php
@@ -1,0 +1,37 @@
+<?php
+
+// This file is part of the Moodle Plugin CI package.
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace MoodlePluginCI\Tests\Fake\Bridge;
+
+/**
+ * Dummy Moodle Fixture class to be able to run PHPDocCommand tests.
+ *
+ * @copyright  2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class DummyMoodlePHPDoc extends DummyMoodle
+{
+    public function normalizeComponent($component): array
+    {
+        return ['local', 'moodlecheck'];
+    }
+
+    public function getComponentInstallDirectory($component): string
+    {
+        return $this->directory . '/local/moodlecheck';
+    }
+}

--- a/tests/Fake/Process/DummyExecute.php
+++ b/tests/Fake/Process/DummyExecute.php
@@ -17,6 +17,8 @@ use Symfony\Component\Process\Process;
 
 class DummyExecute extends Execute
 {
+    public string $returnOutput = '';
+
     private function getMockProcess($cmd)
     {
         $process = \Mockery::mock('Symfony\Component\Process\Process');
@@ -33,7 +35,7 @@ class DummyExecute extends Execute
         );
 
         $process->shouldReceive('isSuccessful')->andReturn(true);
-        $process->shouldReceive('getOutput')->andReturn('');
+        $process->shouldReceive('getOutput')->andReturn($this->returnOutput);
         $process->shouldReceive('getCommandLine')->andReturn($cmd);
 
         return $process;


### PR DESCRIPTION
To be on pair with the PHPCs command, now we support the same option (`--max-warnings xx`) within PHPDocs.

Now, by defaults, warnings will be allowed (previously they were leading to exit with error). And if anybody wants to be stricter, adding `--max-warnings 0` will do the trick. (or any other number if there are a number of warnings to allow).

Covered with (dummy) tests, because the execution of the PHPDoc command requires a complete moodle checkout.

Fixes #186

Note that, before this is merged, these requirements are needed:

- [x] 1. https://github.com/moodlehq/moodle-local_moodlecheck/pull/108 needs to be merged.
- [x] 2. A new release (tag v1.1.5 or up) of local_moodlecheck needs to be done including 1.
- [x] 3. We need to raise moodle-plugin-ci requirements to use that new release performed in 2

So, please, **don't merge this until the 3 requirements above are ticked**. Of course, you're welcome to review it, any time!