### PR TITLE
Bump 402 and master tests from php81 to php82

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.1'
+          - php: '8.2'
             moodle-branch: 'master'
-          - php: '8.1'
+          - php: '8.2'
             moodle-branch: 'MOODLE_402_STABLE'
           - php: '8.1'
             moodle-branch: 'MOODLE_401_STABLE'

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,10 @@ jobs:
 
     - stage: Integration tests
       if: env(MOODLE_BRANCH) IS present
-    - php: 8.1
+    - php: 8.2
       env: MOODLE_BRANCH=master
+    - php: 8.2
+      env: MOODLE_BRANCH=MOODLE_402_STABLE
     - php: 8.1
       env: MOODLE_BRANCH=MOODLE_401_STABLE
     - php: 8.0


### PR DESCRIPTION
With the PHP 8.2 epic (https://tracker.moodle.org/browse/MDL-76405) near being completed, it's time to verify and continuously test that everything is passing with that PHP version.