### PR TITLE
Update to current box version (phar packaging)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
 
-      - name: Setup PHP 7.4
+      - name: Setup PHP 8.1
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           ini-values: phar.readonly = false
 
       - name: Build PHAR

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,11 @@ ifeq (, $(wildcard vendor))
 endif
 
 build/box.phar:
-	@cd build && curl -LSs https://box-project.github.io/box2/installer.php | php
+	curl -LSs https://github.com/box-project/box/releases/download/4.3.8/box.phar -o build/box.phar
 
 build/moodle-plugin-ci.phar: build/box.phar
 	$(COMPOSER) install --no-dev --prefer-dist --classmap-authoritative --quiet
-	php -d memory_limit=-1 -d phar.readonly=false build/box.phar build
+	php -d memory_limit=-1 -d phar.readonly=false build/box.phar compile
 	$(COMPOSER) install --prefer-dist --quiet
 
 docs/CLI.md: $(CMDS)

--- a/box.json
+++ b/box.json
@@ -1,5 +1,4 @@
 {
-  "chmod": "0755",
   "compression": "GZ",
   "directories": [
     "src",
@@ -39,13 +38,11 @@
       ]
     }
   ],
-  "compactors": "Herrera\\Box\\Compactor\\Php",
+  "compactors": "KevinGH\\Box\\Compactor\\Php",
   "git-version": "package_version",
   "replacements": {
     "is_boxed": "BOXED"
   },
   "intercept": true,
-  "main": "bin/moodle-plugin-ci",
-  "output": "build/moodle-plugin-ci.phar",
-  "stub": true
+  "output": "build/moodle-plugin-ci.phar"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Updated the PHAR packaging utility ([box](https://github.com/box-project/box)) to actual one, to avoid various issues happening with PHP 8.1 and up.
+
 ## [4.1.2] - 2023-09-02
 ### Changed
 - Modified `moodle-local_ci` composer dependencies and manage them normally, removing some ancient bits that have [stopped working with Composer 2.6.0 and up](https://github.com/composer/composer/issues/11613).


### PR DESCRIPTION
Current version (2.x) is really old and emitting some warnings with php >= 8.1. So, just move to current 4.x version.

Simply change to its new incarnation (fork of the original) and tidy up a few parameters.

Note that the phar still has a good number of limitations:
- Not all checks work (phpcs, behat...).
- Cannot post-install moodle-local_ci (vnu.jar)
- ...

But all those are pre-existing and this new version does not change that.

Note that box requires PHP 8.1 to build the phar, but the phar works perfectly with PHP 7.4 (our min requirement).

Fixes #235