### PR TITLE
Enable mustache check to run from phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -27,13 +27,13 @@
       "name": [
         "*.php",
         "*.xml",
-        "*.sh"
+        "*.sh",
+        "*.jar"
       ],
       "exclude": [
         "Tests",
         "tests",
         "Docs",
-        "node_modules",
         "pix"
       ]
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Fix the `mustache` command to work from within the PHAR archive.
+
 ## [4.1.3] - 2023-09-08
 ### Changed
 - Updated project dependencies to current [moodle-cs](https://github.com/moodlehq/moodle-cs), [moodle-local_moodlecheck](https://github.com/moodlehq/moodle-local_moodlecheck) and [moodle-local_ci](https://github.com/moodlehq/moodle-local_ci) versions. Also, to various internal / development tools.


### PR DESCRIPTION
We need both the php script and the bundled vnu.jar files to be put in tmp dir and execute/use them from there.

This shouldn't affect normal (non-phar executions). Note that tests cover the non-phar case.