### PR TITLE
Enable phpcs and phpcbf checks to run from phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -36,6 +36,14 @@
         "Docs",
         "pix"
       ]
+    },
+    {
+      "in": "vendor/squizlabs/php_codesniffer",
+      "name": [
+        "phpcs",
+        "phpcbf",
+        "CodeSniffer.conf"
+      ]
     }
   ],
   "compactors": "KevinGH\\Box\\Compactor\\Php",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ## [Unreleased]
 ### Fixed
 - Fix the `mustache` command to work from within the PHAR archive.
+- Fix the `phpcs` and `phpcbf` commands to work from within the PHAR archive.
 
 ## [4.1.3] - 2023-09-08
 ### Changed


### PR DESCRIPTION
Note this is very similar to #237 (that **should be merged before this**).

We need the 2 CLI scripts and the CodeSniffer.conf file to be added to the phar, so we can "include" the scripts for execution and copy the conf file temporarily to be together with the phar (that's the way CodeSniffer expects it).

Note this will reduce a little bit code-coverage but in a future PR I want to add some integration tests to cover the execution from phar, hardly can be done from unit tests.