### PR TITLE
Remove CI testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,19 +87,12 @@ jobs:
 
     - stage: Integration tests
       if: env(MOODLE_BRANCH) IS present
+    # Only master with highest supported PHP version.
     - php: 8.2
       env: MOODLE_BRANCH=master
+    # Last stable with highest supported PHP version.
     - php: 8.2
       env: MOODLE_BRANCH=MOODLE_402_STABLE
-    - php: 8.1
-      env: MOODLE_BRANCH=MOODLE_401_STABLE
-    - php: 8.0
-      env: MOODLE_BRANCH=MOODLE_400_STABLE
-    - php: 8.0
-      env: MOODLE_BRANCH=MOODLE_311_STABLE
-    - php: 7.4
-      env: MOODLE_BRANCH=MOODLE_310_STABLE
-    - php: 7.4
-      env: MOODLE_BRANCH=MOODLE_39_STABLE
+    # And oldest stable supported (with lowest supported PHP version).
     - php: 7.4
       env: MOODLE_BRANCH=MOODLE_38_STABLE


### PR DESCRIPTION
To be done after #239

While we still keep moodle-plugin-ci officially supported with Travis, it just so slow (for our current paid plan) that make any branch or PR to take ages to be tested (~1 hour).

So here we are reducing the number of branches being tested to:
- master (highest PHP version supported).
- latest stable (highest PHP version supported).
- oldest stable supported (lowest PHP version supported).

That will save some precious minutes (7-8 per run) making things a little bit more agile, specially given the falling relevance of Travis since a couple of years ago (compared with the raise of GHA).