### PR TITLE
Update .gitattributes to current files to keep out from packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,19 +1,20 @@
-# Path-based git attributes
-# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
-
-# Ignore all test and documentation with "export-ignore".
-/build              export-ignore
-/doc                export-ignore
-/tests              export-ignore
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.php_cs            export-ignore
-/.travis.dist.yml   export-ignore
-/.travis.yml        export-ignore
-/box.json           export-ignore
-/CHANGELOG.md       export-ignore
-/CONTRIBUTING.md    export-ignore
-/Makefile           export-ignore
-/phpunit.xml.dist   export-ignore
-/README.md          export-ignore
-/UPGRADE-*.md       export-ignore
+# Ignore all these files for release packages.
+# Using Composer `--prefer-dist` will not include these files.
+# Use `--prefer-source` to include them.
+# See https://blog.madewithlove.be/post/gitattributes/
+.gitattributes     export-ignore
+.gitignore         export-ignore
+.php-cs-fixer.php  export-ignore
+.travis.dist.yml   export-ignore
+.travis.yml        export-ignore
+CONTRIBUTING.md    export-ignore
+Makefile           export-ignore
+README.md          export-ignore
+box.json           export-ignore
+gha.dist.yml       export-ignore
+phpunit.xml.dist   export-ignore
+psalm.xml          export-ignore
+/.github           export-ignore
+/build             export-ignore
+/docs              export-ignore
+/tests             export-ignore


### PR DESCRIPTION
We had not updated this file since long ago and there are some new/moved paths to get excluded from distribution when installed as a dependency.