### PR TITLE
Add back the selfupdate command (interim mode)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
     "psr/log": "^1.1.4",
     "nikic/php-parser": "^4.14",
     "marcj/topsort": "^2.0.0",
-    "phpcompatibility/php-compatibility": "dev-develop#0a17f9ed"
+    "phpcompatibility/php-compatibility": "dev-develop#0a17f9ed",
+    "laravel-zero/phar-updater": "^1.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d43390a9033fc4baebe8b85a26a92a6a",
+    "content-hash": "c8ab969e776fe6e549ad37df232a907f",
     "packages": [
         {
             "name": "composer/pcre",
@@ -220,6 +220,61 @@
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
             "time": "2023-01-05T11:28:13+00:00"
+        },
+        {
+            "name": "laravel-zero/phar-updater",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel-zero/phar-updater.git",
+                "reference": "ac583f0983f91df9ca18c31ef6fd44dd51820495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel-zero/phar-updater/zipball/ac583f0983f91df9ca18c31ef6fd44dd51820495",
+                "reference": "ac583f0983f91df9ca18c31ef6fd44dd51820495",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3|^8.0"
+            },
+            "conflict": {
+                "padraic/phar-updater": "*"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "phpstan/phpstan": "^0.12.85",
+                "phpunit/phpunit": "^9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Humbug\\SelfUpdate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Padraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                }
+            ],
+            "description": "A thing to make PHAR self-updating easy and secure.",
+            "keywords": [
+                "humbug",
+                "phar",
+                "self-update",
+                "update"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel-zero/phar-updater/issues",
+                "source": "https://github.com/laravel-zero/phar-updater/tree/v1.1.1"
+            },
+            "time": "2021-08-03T08:29:40+00:00"
         },
         {
             "name": "marcj/topsort",

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -25,6 +25,7 @@ class SelfUpdateCommand extends Command
     protected function configure(): void
     {
         $this->setName('selfupdate')
+            ->setAliases(['self-update'])
             ->setDescription('Updates moodle-plugin-ci')
             ->addOption('rollback', 'r', InputOption::VALUE_NONE, 'Rollback to the last version')
             ->addOption('preview', null, InputOption::VALUE_NONE, 'Update to pre-release version')


### PR DESCRIPTION
The self update command dependencies were removed in the past but the command was left around. As a result of that any attempt of running:

`php moodle-plugin-ci.phar selfupdate`

Is failing with PHP error (because the underlying humbug/phar-updater library was not available any more.

So, with this commit, we are re-introducing it, but with the following observations:

1. We have moved from humbug/phar-updater (archived) to laravel-zero/phar-updater that is maintained.
2. We are stuck to version 1.*, because of we still supporting PHP 7.4
3. I've run it with PHP 8.2 and it doesn't break badly, just some PHP deprecated notices are displayed. In any case, far better than the previous status, not working at all.
4. Having it back to code will allow us to further progress:
   - Getting it tested with some new integration test.
   - Have time to look if there is any other fork with relaxed requirements (or make our own one).
   - Try other selfupdate alternatives. Certainly the one we are currently using is the most advanced ones, although for basic usage (no rollback, no keys verification...) there are a few, with `consolidation/self-update` surely being the more active (again knowing that it's way simpler).

And that's the story of this PR, basically just keep the selfupdate command working (knowing that emits a few PHP notices with PHP 8.x) but allowing us to test it and try other alternatives in the future.