### PR TITLE
Add tests to cover what is testable in SelfUpdate command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,3 +261,45 @@ jobs:
         php build/moodle-plugin-ci.phar behat --profile default
         php build/moodle-plugin-ci.phar behat --profile chrome
         php build/moodle-plugin-ci.phar behat --profile firefox --tags="@local_ci&&~@app"
+
+  selfupdatetest:
+    name: SelfUpdate tests (PHAR)
+    runs-on: ubuntu-22.04
+    env:
+      lowest_release: '4.1.8'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Each supported PHP version once. That's enough.
+          - php: '8.2'
+          - php: '8.1'
+          - php: '8.0'
+          - php: '7.4'
+
+    steps:
+    - name: Setup PHP ${{ matrix.php }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: pgsql, zip, gd, xmlrpc, soap
+        ini-values: max_input_vars=5000
+        coverage: none
+
+    - name: Download base ${{ env.lowest_release }} PHAR artifact
+      uses: robinraju/release-downloader@v1.8
+      with:
+        repository: moodlehq/moodle-plugin-ci
+        tag: ${{ env.lowest_release }}
+        fileName: moodle-plugin-ci.phar
+
+    - name: Self update PHAR to actual
+      run: |
+        php moodle-plugin-ci.phar selfupdate
+        php moodle-plugin-ci.phar --version | grep -qv "${{ env.lowest_release }}"
+
+    - name: Self update rollback PHAR to base ${{ env.lowest_release }}
+      run: |
+        php moodle-plugin-ci.phar selfupdate --rollback
+        php moodle-plugin-ci.phar --version | grep -q "${{ env.lowest_release }}"

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -93,13 +93,17 @@ class SelfUpdateCommand extends Command
     }
 
     /**
+     * Calculate the full path where the old PHAR file will be backup (to be able to roll back to it).
+     *
+     * @param string|null $directory the directory where the backup will be stored
+     *
      * @return string
      */
-    protected function getBackupPath(): string
+    protected function getBackupPath(?string $directory = null): string
     {
-        $directory = getenv('HOME');
+        $directory = $directory ?? getenv('HOME'); // Default to $HOME as base directory if not provided.
         if (empty($directory) || !is_dir($directory)) {
-            throw new \RuntimeException('Your $HOME enviroment variable is either not set or is not a directory');
+            throw new \RuntimeException("The {$directory} path is not an existing directory");
         }
         $directory .= '/.moodle-plugin-ci';
 

--- a/tests/Command/SelfUpdateCommandTest.php
+++ b/tests/Command/SelfUpdateCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
+ */
+
+namespace Command;
+
+use MoodlePluginCI\Command\SelfUpdateCommand;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Tests for the SelfUpdateCommand class.
+ *
+ * There isn't much to test here, only helper methods. Note that the utility itself
+ * will be covered by some integration tests @ CIs.
+ */
+class SelfUpdateCommandTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @covers \MoodlePluginCI\Command\SelfUpdateCommand::getBackupPath
+     */
+    public function testGetBackupPathNotExists()
+    {
+        $command = new SelfUpdateCommand();
+
+        // Try with a non-existing directory.
+        $rollBackDir  = sys_get_temp_dir() . '/not_existing_dir';
+        $rollBackFile = $rollBackDir . '/.moodle-plugin-ci/moodle-plugin-ci-old.phar';
+
+        $this->expectException(\RuntimeException::class);
+
+        // Use reflection to test the protected method.
+        $method = new \ReflectionMethod($command, 'getBackupPath');
+        $method->setAccessible(true);
+        $this->assertSame($rollBackFile, $method->invoke($command, $rollBackDir));
+    }
+
+    /**
+     * @covers \MoodlePluginCI\Command\SelfUpdateCommand::getBackupPath
+     */
+    public function testGetBackupPathExists()
+    {
+        $command = new SelfUpdateCommand();
+
+        // Try with a existing directory.
+        $rollBackDir = sys_get_temp_dir() . '/existing_dir';
+        (new Filesystem())->mkdir($rollBackDir); // Let's create the directory.
+        $rollBackFile = $rollBackDir . '/.moodle-plugin-ci/moodle-plugin-ci-old.phar';
+
+        // Use reflection to test the protected method.
+        $method = new \ReflectionMethod($command, 'getBackupPath');
+        $method->setAccessible(true);
+        $this->assertSame($rollBackFile, $method->invoke($command, $rollBackDir));
+    }
+}


### PR DESCRIPTION
Note that only helper methods can be tested for that command, not the execution of the update itself (it has to happen within a PHAR). And it doesn't make much sense to start mocking lots of stuff for that.

Some integration tests @ CIS will be in charge of
covering the real execution instead. Coming soon.