### PR TITLE
New behat phpunit options

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,8 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 
 ## [Unreleased]
 ### Added
-- Added support for the `--tags` and `--name` options into the `behat` command.
+- Added support for the `--tags` and `--name` options to the `behat` command.
+- Added support for the `--configure`, `--testsuite` and `--filter` options to the `phpunit` command.
 
 ### Changed
 - ACTION SUGGESTED: If you are using GitHub Actions, it's recomended to use `!cancelled()` instead of `always()` for moodle-plugin-ci tests. Adding a final step that always returns failure when the workflow is cancelled will ensure that cancelled workflows are not marked as successful. For a working example, please reference the updated `gha.dist.yml` file.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Added support for the `--tags` and `--name` options into the `behat` command.
+
 ### Changed
 - ACTION SUGGESTED: If you are using GitHub Actions, it's recomended to use `!cancelled()` instead of `always()` for moodle-plugin-ci tests. Adding a final step that always returns failure when the workflow is cancelled will ensure that cancelled workflows are not marked as successful. For a working example, please reference the updated `gha.dist.yml` file.
 - ACTION SUGGESTED: For some (unknown) reason, Travis environments with PHP 8.2 have started to fail with error:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1975,7 +1975,7 @@ Run PHPUnit on a plugin
 
 ### Usage
 
-* `phpunit [-m|--moodle MOODLE] [--coverage-text] [--coverage-clover] [--coverage-pcov] [--coverage-xdebug] [--coverage-phpdbg] [--fail-on-incomplete] [--fail-on-risky] [--fail-on-skipped] [--fail-on-warning] [--testdox] [--] <plugin>`
+* `phpunit [-m|--moodle MOODLE] [-c|--configuration CONFIGURATION] [--testsuite TESTSUITE] [--filter FILTER] [--testdox] [--coverage-text] [--coverage-clover] [--coverage-pcov] [--coverage-xdebug] [--coverage-phpdbg] [--fail-on-incomplete] [--fail-on-risky] [--fail-on-skipped] [--fail-on-warning] [--] <plugin>`
 
 Run PHPUnit on a plugin
 
@@ -2000,6 +2000,46 @@ Path to Moodle
 * Is multiple: no
 * Is negatable: no
 * Default: `'.'`
+
+#### `--configuration|-c`
+
+PHPUnit configuration XML file (relative to plugin directory)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `NULL`
+
+#### `--testsuite`
+
+PHPUnit testsuite option to use (must exist in the configuration file being used)
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `NULL`
+
+#### `--filter`
+
+PHPUnit filter option to use
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `NULL`
+
+#### `--testdox`
+
+Enable testdox formatter
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
 
 #### `--coverage-text`
 
@@ -2084,16 +2124,6 @@ Treat skipped tests as failures
 #### `--fail-on-warning`
 
 Treat tests with warnings as failures
-
-* Accept value: no
-* Is value required: no
-* Is multiple: no
-* Is negatable: no
-* Default: `false`
-
-#### `--testdox`
-
-Enable testdox formatter
 
 * Accept value: no
 * Is value required: no

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -241,7 +241,7 @@ Run Behat on a plugin
 
 ### Usage
 
-* `behat [-m|--moodle MOODLE] [-p|--profile PROFILE] [--suite SUITE] [--start-servers] [--auto-rerun AUTO-RERUN] [--dump] [--] <plugin>`
+* `behat [-m|--moodle MOODLE] [-p|--profile PROFILE] [--suite SUITE] [--tags TAGS] [--name NAME] [--start-servers] [--auto-rerun AUTO-RERUN] [--dump] [--] <plugin>`
 
 Run Behat on a plugin
 
@@ -269,7 +269,7 @@ Path to Moodle
 
 #### `--profile|-p`
 
-Behat profile to use
+Behat profile option to use
 
 * Accept value: yes
 * Is value required: yes
@@ -279,13 +279,33 @@ Behat profile to use
 
 #### `--suite`
 
-Behat suite to use (Moodle theme)
+Behat suite option to use (Moodle theme)
 
 * Accept value: yes
 * Is value required: yes
 * Is multiple: no
 * Is negatable: no
 * Default: `'default'`
+
+#### `--tags`
+
+Behat tags option to use. If not set, defaults to the component name
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `''`
+
+#### `--name`
+
+Behat name option to use
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `''`
 
 #### `--start-servers`
 

--- a/src/Command/BehatCommand.php
+++ b/src/Command/BehatCommand.php
@@ -58,8 +58,11 @@ class BehatCommand extends AbstractMoodleCommand
         parent::configure();
 
         $this->setName('behat')
-            ->addOption('profile', 'p', InputOption::VALUE_REQUIRED, 'Behat profile to use', 'default')
-            ->addOption('suite', null, InputOption::VALUE_REQUIRED, 'Behat suite to use (Moodle theme)', 'default')
+            ->addOption('profile', 'p', InputOption::VALUE_REQUIRED, 'Behat profile option to use', 'default')
+            ->addOption('suite', null, InputOption::VALUE_REQUIRED, 'Behat suite option to use (Moodle theme)', 'default')
+            ->addOption('tags', null, InputOption::VALUE_REQUIRED, 'Behat tags option to use. ' .
+                'If not set, defaults to the component name', '')
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Behat name option to use', '')
             ->addOption('start-servers', null, InputOption::VALUE_NONE, 'Start Selenium and PHP servers')
             ->addOption('auto-rerun', null, InputOption::VALUE_REQUIRED, 'Number of times to rerun failures', 2)
             ->addOption('dump', null, InputOption::VALUE_NONE, 'Print contents of Behat failure HTML files')
@@ -89,13 +92,18 @@ class BehatCommand extends AbstractMoodleCommand
 
         $cmd = [
             'php', 'admin/tool/behat/cli/run.php',
-            '--tags=@' . $this->plugin->getComponent(),
             '--profile=' . $input->getOption('profile'),
             '--suite=' . $input->getOption('suite'),
+            '--tags=' . ($input->getOption('tags') ?: '@' . $this->plugin->getComponent()),
             '--auto-rerun=' . $input->getOption('auto-rerun'),
             '--verbose',
             '-vvv',
         ];
+
+        $name = $input->getOption('name');
+        if (!empty($name) && is_string($name)) {
+            $cmd[] = '--name=\'' . $name . '\'';
+        }
 
         if ($output->isDecorated()) {
             $cmd[] = '--colors';

--- a/tests/MoodleTestCase.php
+++ b/tests/MoodleTestCase.php
@@ -16,6 +16,7 @@ class MoodleTestCase extends FilesystemTestCase
 {
     protected string $moodleDir;
     protected string $pluginDir;
+    protected string $lastCmd = ''; // We need this for assertions against the command run.
 
     protected function setUp(): void
     {
@@ -23,6 +24,7 @@ class MoodleTestCase extends FilesystemTestCase
 
         $this->moodleDir = $this->tempDir;
         $this->pluginDir = $this->tempDir . '/local/ci';
+        $this->lastCmd   = '';
 
         $this->fs->mirror(__DIR__ . '/Fixture/moodle', $this->moodleDir);
         $this->fs->mirror(__DIR__ . '/Fixture/moodle-local_ci', $this->pluginDir);


### PR DESCRIPTION
This PR has 3 commits:

1. Modify `DummyExecute` in order to make the last command executed available for testing purposes.
2. Add the `--tags` and `--name` Behat options available (#246).
3. Add the `--configure`, `--testsuite` and `--fillter` PHPUnit options available (#100).

I've added 2 `TODOs` in the code about some tests that, IMO, are wrong. They are pre-existing and won't be analysed or fixed here.

Ciao :-)