### PR TITLE
Add the libonig5 to the Travis packages to install

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -8,6 +8,7 @@ addons:
     packages:
       - postgresql-13
       - postgresql-client-13
+      - libonig5
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
       - postgresql-13
       - postgresql-client-13
+      - libonig5
 
 services:
   - mysql

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,13 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ## [Unreleased]
 ### Changed
 - ACTION SUGGESTED: If you are using GitHub Actions, it's recomended to use `!cancelled()` instead of `always()` for moodle-plugin-ci tests. Adding a final step that always returns failure when the workflow is cancelled will ensure that cancelled workflows are not marked as successful. For a working example, please reference the updated `gha.dist.yml` file.
+- ACTION SUGGESTED: For some (unknown) reason, Travis environments with PHP 8.2 have started to fail with error:
+
+  ```
+  php: error while loading shared libraries: libonig.so.5
+  ```
+
+  To avoid that problem it's recommended to to add the `libonig5` package to the `travis.yml` file. For a working example, please reference the updated `.travis.dist.yml`file.
 
 ## [4.1.8] - 2023-10-20
 ### Changed

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -21,6 +21,7 @@ addons:
     packages:
       - postgresql-13
       - postgresql-client-13
+      - libonig5
 
 # Ensure DB and docker services are running.
 services:


### PR DESCRIPTION
For some strange reason, travis has started to fail with PHP 8.2 with error:

php: error while loading shared libraries: libonig.so.5

It was not happening few days ago. Searching out there it seems that the fix is as simple as apt-installing that library.

It's incredible that they don't have that implemented in their environments and things like this need to be installed manually.

Any way, fixed in our own Travis test and also in the template and docs.