### PR TITLE
Implement --exclude option in phpcs command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Added support for the `--exclude` option to the `phpcs` command.
+
 ## [4.2.0] - 2023-11-30
 ### Added
 - Added support for the `--tags` and `--name` options to the `behat` command.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1619,6 +1619,16 @@ Version or range of version to test with PHPCompatibility
 * Is negatable: no
 * Default: `0`
 
+#### `--exclude|-x`
+
+Comma separated list of sniff codes to exclude from checking
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Is negatable: no
+* Default: `''`
+
 #### `--help|-h`
 
 Display help for the given command. When no command is given display help for the list command

--- a/src/Command/CodeCheckerCommand.php
+++ b/src/Command/CodeCheckerCommand.php
@@ -39,6 +39,7 @@ class CodeCheckerCommand extends AbstractPluginCommand
             ->setAliases(['codechecker'])
             ->setDescription('Run Moodle CodeSniffer standard on a plugin')
             ->addOption('standard', 's', InputOption::VALUE_REQUIRED, 'The name or path of the coding standard to use', 'moodle')
+            ->addOption('exclude', 'x', InputOption::VALUE_REQUIRED, 'Comma separated list of sniff codes to exclude from checking', '')
             ->addOption('max-warnings', null, InputOption::VALUE_REQUIRED,
                 'Number of warnings to trigger nonzero exit code - default: -1', -1)
             ->addOption('test-version', null, InputOption::VALUE_REQUIRED,
@@ -77,13 +78,15 @@ class CodeCheckerCommand extends AbstractPluginCommand
         }
         // @codeCoverageIgnoreEnd
 
-        $cmd = array_merge($basicCMD, [
+        $exclude = $input->getOption('exclude');
+        $cmd     = array_merge($basicCMD, [
             '--standard=' . ($input->getOption('standard') ?: 'moodle'),
             '--extensions=php',
             '-p',
             '-w',
             '-s',
             '--no-cache',
+            empty($exclude) ? '' : ('--exclude=' . $exclude),
             $output->isDecorated() ? '--colors' : '--no-colors',
             '--report-full',
             '--report-width=132',


### PR DESCRIPTION
I've been trying to exclude some rules from a plugin using a `.phpcs.xml` file and I didn't manage to do it. But it was very easy using [the exclude option](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#limiting-results-to-specific-sniffs). I think this would be a nice addition.