### PR TITLE
deprecates integration with PHP Copy/Paste Detector (PHPCPD) library.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,9 +9,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+
 ### Changed
 - Updated all uses of `actions/checkout` from `v3` (using node 16) to `v4` (using node 20), because [actions using node 16 are deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and will stop working in the future.
 * ACTION SUGGESTED: In order to avoid the node 16 deprecation warnings, update your workflows to use `actions/checkout@v4`.
+
+### Deprecated
+- The `phpcpd` command (that uses the [PHP Copy/Paste Detector](https://github.com/sebastianbergmann/phpcpd), now abandoned) has been deprecated in this `moodle-plugin-ci` release (4.4.0) and will be removed in 5.0.0. No replacement is planned.
+- ACTION SUGGESTED: In order to avoid deprecation warnings or annotations, proceed to remove this command from your workflows. Note that any use will throw an error in the next major release (5.0.0).
 
 ## [4.3.2] - 2024-01-26
 ### Changed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,7 +19,7 @@ title: Moodle Plugin CI Commands
 * [`mustache`](#mustache)
 * [`parallel`](#parallel)
 * [`phpcbf`](#phpcbf)
-* [`phpcpd`](#phpcpd)
+* [`phpcpd` (DEPRECATED)](#phpcpd)
 * [`phpcs`](#phpcs)
 * [`phpdoc`](#phpdoc)
 * [`phplint`](#phplint)
@@ -1485,7 +1485,15 @@ Do not ask any interactive question
 `phpcpd`
 --------
 
-Run PHP Copy/Paste Detector on a plugin
+Run PHP Copy/Paste Detector on a plugin.
+
+### Deprecation Notice
+
+[PHP Copy/Paste Detector](https://github.com/sebastianbergmann/phpcpd) has been abandoned by its maintainers.
+
+The integration with it will be removed without replacement from future versions of this plugin.
+
+_Usage of the `phpcpd` command is discouraged._
 
 ### Usage
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,7 +19,7 @@ title: Moodle Plugin CI Commands
 * [`mustache`](#mustache)
 * [`parallel`](#parallel)
 * [`phpcbf`](#phpcbf)
-* [`phpcpd` (DEPRECATED)](#phpcpd)
+* [`phpcpd`](#phpcpd)
 * [`phpcs`](#phpcs)
 * [`phpdoc`](#phpdoc)
 * [`phplint`](#phplint)
@@ -1485,21 +1485,13 @@ Do not ask any interactive question
 `phpcpd`
 --------
 
-Run PHP Copy/Paste Detector on a plugin.
-
-### Deprecation Notice
-
-[PHP Copy/Paste Detector](https://github.com/sebastianbergmann/phpcpd) has been abandoned by its maintainers.
-
-The integration with it will be removed without replacement from future versions of this plugin.
-
-_Usage of the `phpcpd` command is discouraged._
+Run PHP Copy/Paste Detector on a plugin (**DEPRECATED**)
 
 ### Usage
 
 * `phpcpd <plugin>`
 
-Run PHP Copy/Paste Detector on a plugin
+Run PHP Copy/Paste Detector on a plugin (**DEPRECATED**)
 
 ### Arguments
 

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -142,7 +142,7 @@ jobs:
         if: ${{ !cancelled() }} # prevents CI run stopping if step failed.
         run: moodle-plugin-ci phplint
 
-      - name: PHP Copy/Paste Detector
+      - name: PHP Copy/Paste Detector # DEPRECATED
         continue-on-error: true # This step will show errors but will not fail
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci phpcpd

--- a/docs/Help.md
+++ b/docs/Help.md
@@ -27,7 +27,7 @@ inclide in the CI scenario. For detailed information, see [CLI commands and opti
 
 This step lints your PHP files to check for syntax errors.
 
-**moodle-plugin-ci phpcpd**
+**moodle-plugin-ci phpcpd (DEPRECATED)**
 
 This step runs the PHP Copy/Paste Detector on your plugin. This helps to find
 code duplication.

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -131,6 +131,7 @@ script:
   - moodle-plugin-ci phplint
 # This step runs the PHP Copy/Paste Detector on your plugin.
 # This helps to find code duplication.
+# (DEPRECATED)
   - moodle-plugin-ci phpcpd
 # This step runs the PHP Mess Detector on your plugin. This helps to find
 # potential problems with your code which can result in

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ This project supports the following testing frameworks and code analysis tools:
 * [Mustache Linting](https://docs.moodle.org/dev/Templates)
 * [Grunt tasks](https://docs.moodle.org/dev/Grunt)
 * [PHP Linting](https://github.com/JakubOnderka/PHP-Parallel-Lint)
-* [PHP Copy/Paste Detector](https://github.com/sebastianbergmann/phpcpd)
+* [PHP Copy/Paste Detector (DEPRECATED)](https://github.com/sebastianbergmann/phpcpd)
 * [PHP Mess Detector](http://phpmd.org)
 
 ## Requirements

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,4 +11,7 @@
       <directory suffix=".php">./src/</directory>
     </include>
   </coverage>
+  <php>
+    <const name="PHPUNIT_TEST" value="true"/>
+  </php>
 </phpunit>

--- a/src/Command/CopyPasteDetectorCommand.php
+++ b/src/Command/CopyPasteDetectorCommand.php
@@ -23,6 +23,8 @@ use Symfony\Component\Finder\Finder;
 
 /**
  * Run PHP Copy/Paste Detector on a plugin.
+ *
+ * @deprecated
  */
 class CopyPasteDetectorCommand extends AbstractPluginCommand
 {
@@ -31,7 +33,7 @@ class CopyPasteDetectorCommand extends AbstractPluginCommand
         parent::configure();
 
         $this->setName('phpcpd')
-            ->setDescription('Run PHP Copy/Paste Detector on a plugin');
+            ->setDescription('Run PHP Copy/Paste Detector on a plugin (DEPRECATED)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/CopyPasteDetectorCommand.php
+++ b/src/Command/CopyPasteDetectorCommand.php
@@ -24,7 +24,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * Run PHP Copy/Paste Detector on a plugin.
  *
- * @deprecated
+ * @deprecated Since 4.4.0, to be removed in 5.0.0. No replacement is planned.
  */
 class CopyPasteDetectorCommand extends AbstractPluginCommand
 {
@@ -33,11 +33,25 @@ class CopyPasteDetectorCommand extends AbstractPluginCommand
         parent::configure();
 
         $this->setName('phpcpd')
-            ->setDescription('Run PHP Copy/Paste Detector on a plugin (DEPRECATED)');
+            ->setDescription('Run PHP Copy/Paste Detector on a plugin (**DEPRECATED**)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if (!defined('PHPUNIT_TEST')) { // Only show deprecation warnings in non-test environments.
+            trigger_deprecation(
+                'moodle-plugin-ci',
+                '4,4,0',
+                'The "%s" command is deprecated and will be removed in %s. No replacement is planned.',
+                $this->getName(),
+                '5.0.0'
+            );
+            if (getenv('GITHUB_ACTIONS')) { // Only show deprecation annotations in GitHub Actions.
+                echo '::warning title=Deprecated command::The phpcpd command ' .
+                    'is deprecated and will be removed in 5.0.0. No replacement is planned.' . PHP_EOL;
+            }
+        }
+
         $timer = new Timer();
         $timer->start();
 


### PR DESCRIPTION
deprecation as a stepping stone towards full removal. 

i tried to be cheeky by triggering a deprecation error when the command is executed, but that didn't pan out. 
so it's all documentation, and one `@deprecated` annotation on the command itself.

refs #262 
refs #263 