### PR TITLE
Allow selenium image configuration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+
+### Added
+- `--selenium` option or `MOODLE_BEHAT_SELENIUM_IMAGE` env variable to `behat` to specify Selenium Docker image.
+
 ### Changed
 - Updated all uses of `actions/checkout` from `v3` (using node 16) to `v4` (using node 20), because [actions using node 16 are deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and will stop working in the future.
 - ACTION SUGGESTED: In order to avoid the node 16 deprecation warnings, update your workflows to use `actions/checkout@v4`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -241,7 +241,7 @@ Run Behat on a plugin
 
 ### Usage
 
-* `behat [-m|--moodle MOODLE] [-p|--profile PROFILE] [--suite SUITE] [--tags TAGS] [--name NAME] [--start-servers] [--auto-rerun AUTO-RERUN] [--dump] [--] <plugin>`
+* `behat [-m|--moodle MOODLE] [-p|--profile PROFILE] [--suite SUITE] [--tags TAGS] [--name NAME] [--start-servers] [--auto-rerun AUTO-RERUN] [--selenium SELENIUM] [--dump] [--] <plugin>`
 
 Run Behat on a plugin
 
@@ -326,6 +326,16 @@ Number of times to rerun failures
 * Is multiple: no
 * Is negatable: no
 * Default: `2`
+
+#### `--selenium`
+
+Selenium Docker image
+
+* Accept value: yes
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `NULL`
 
 #### `--dump`
 

--- a/tests/Command/BehatCommandTest.php
+++ b/tests/Command/BehatCommandTest.php
@@ -46,7 +46,10 @@ class BehatCommandTest extends MoodleTestCase
             $cmdOptions
         );
         $commandTester->execute($cmdOptions);
-        $this->lastCmd = $command->execute->lastCmd; // We need this for assertions against the command run.
+
+        // We need these for assertions against the commands run.
+        $this->allCmds = $command->execute->allCmds;
+        $this->lastCmd = $command->execute->lastCmd;
 
         return $commandTester;
     }
@@ -67,6 +70,51 @@ class BehatCommandTest extends MoodleTestCase
         $this->assertSame(0, $commandTester->getStatusCode());
         $this->assertMatchesRegularExpression('/--tags=@tag1&&@tag2/', $this->lastCmd);
         $this->assertDoesNotMatchRegularExpression('/--tags=@local_ci/', $this->lastCmd);
+    }
+
+    public function testExecuteWithSeleniumImageOption()
+    {
+        $commandTester = $this->executeCommand(null, null, ['--start-servers' => true, '--selenium' => 'seleniarm/standalone-chromium:latest']);
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/seleniarm\/standalone-chromium:latest/', $this->allCmds[1]);
+    }
+
+    public function testExecuteWithSeleniumImageEnv()
+    {
+        putenv('MOODLE_BEHAT_SELENIUM_IMAGE=seleniarm/standalone-chromium:latest');
+
+        $commandTester = $this->executeCommand(null, null, ['--start-servers' => true]);
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/seleniarm\/standalone-chromium:latest/', $this->allCmds[1]);
+    }
+
+    public function testExecuteWithChromeProfile()
+    {
+        putenv('MOODLE_BEHAT_SELENIUM_IMAGE=');
+
+        $commandTester = $this->executeCommand(null, null, ['--start-servers' => true, '--profile' => 'chrome']);
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/selenium\/standalone-chrome:3/', $this->allCmds[1]);
+    }
+
+    public function testExecuteWithFirefoxProfile()
+    {
+        putenv('MOODLE_BEHAT_SELENIUM_IMAGE=');
+        file_put_contents("{$this->moodleDir}/composer.lock", '');
+
+        $commandTester = $this->executeCommand(null, null, ['--start-servers' => true, '--profile' => 'firefox']);
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/selenium\/standalone-firefox:3/', $this->allCmds[1]);
+    }
+
+    public function testExecuteWithLegacyFirefoxProfile()
+    {
+        putenv('MOODLE_BEHAT_SELENIUM_IMAGE=');
+        file_put_contents("{$this->moodleDir}/composer.lock", 'instaclick/php-webdriver');
+
+        $commandTester = $this->executeCommand(null, null, ['--start-servers' => true, '--profile' => 'firefox']);
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/selenium\/standalone-firefox:2.53.1/', $this->allCmds[1]);
     }
 
     public function testExecuteWithName()

--- a/tests/Command/PHPUnitCommandTest.php
+++ b/tests/Command/PHPUnitCommandTest.php
@@ -45,7 +45,10 @@ class PHPUnitCommandTest extends MoodleTestCase
             $cmdOptions
         );
         $commandTester->execute($cmdOptions);
-        $this->lastCmd = $command->execute->lastCmd; // We need this for assertions against the command run.
+
+        // We need these for assertions against the commands run.
+        $this->allCmds = $command->execute->allCmds;
+        $this->lastCmd = $command->execute->lastCmd;
 
         return $commandTester;
     }

--- a/tests/MoodleTestCase.php
+++ b/tests/MoodleTestCase.php
@@ -16,7 +16,10 @@ class MoodleTestCase extends FilesystemTestCase
 {
     protected string $moodleDir;
     protected string $pluginDir;
-    protected string $lastCmd = ''; // We need this for assertions against the command run.
+
+    // We need these for assertions against the commands run.
+    protected array $allCmds  = [];
+    protected string $lastCmd = '';
 
     protected function setUp(): void
     {
@@ -24,6 +27,7 @@ class MoodleTestCase extends FilesystemTestCase
 
         $this->moodleDir = $this->tempDir;
         $this->pluginDir = $this->tempDir . '/local/ci';
+        $this->allCmds   = [];
         $this->lastCmd   = '';
 
         $this->fs->mirror(__DIR__ . '/Fixture/moodle', $this->moodleDir);


### PR DESCRIPTION
I've decided to remove the private properties because they were only used once, and now everything is encapsulated in the `getSeleniumImage` method.

Other than that, there isn't much more to the PR. It allows to configure the selenium image by setting `MOODLE_BEHAT_SELENIUM_IMAGE`, or specify it for each profile with `MOODLE_BEHAT_SELENIUM_CHROME_IMAGE` and `MOODLE_BEHAT_SELENIUM_FIREFOX_IMAGE`.

I also pondered whether to allow indicating only the browser version. For example, setting `MOODLE_BEHAT_CHROME_VERSION` or accepting `chrome:117` for the profile. But I wasn't convinced by that approach, so I ended up using this one that also allows customizing the image completely (for example, in case [you'd need to use seleniarm](https://github.com/moodlehq/moodle-docker/pull/250) or something else).