### PR TITLE
Configure browser capabilities

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 
 ### Added
 - `--selenium` option or `MOODLE_BEHAT_SELENIUM_IMAGE` env variable to `behat` to specify Selenium Docker image.
+- `MOODLE_BEHAT_CHROME_CAPABILITIES` and `MOODLE_BEHAT_FIREFOX_CAPABILITIES` env variables to configure additional browser capabilities.
 
 ### Changed
 - Updated all uses of `actions/checkout` from `v3` (using node 16) to `v4` (using node 20), because [actions using node 16 are deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and will stop working in the future.

--- a/res/template/config.php.txt
+++ b/res/template/config.php.txt
@@ -43,16 +43,19 @@ $CFG->behat_wwwroot       = '{{BEHATWWWROOT}}';
 $CFG->behat_faildump_path = '{{BEHATDUMP}}';
 $CFG->behat_profiles      = [
     'default' => [
-        'browser' => '{{BEHATDEFAULTBROWSER}}',
-        'wd_host' => '{{BEHATWDHOST}}',
+        'browser'      => '{{BEHATDEFAULTBROWSER}}',
+        'wd_host'      => '{{BEHATWDHOST}}',
+        'capabilities' => {{BEHATDEFAULTCAPABILITIES}},
     ],
     'chrome' => [
-        'browser' => 'chrome',
-        'wd_host' => '{{BEHATWDHOST}}',
+        'browser'      => 'chrome',
+        'wd_host'      => '{{BEHATWDHOST}}',
+        'capabilities' => {{BEHATCHROMECAPABILITIES}},
     ],
     'firefox' => [
-        'browser' => 'firefox',
-        'wd_host' => '{{BEHATWDHOST}}',
+        'browser'      => 'firefox',
+        'wd_host'      => '{{BEHATWDHOST}}',
+        'capabilities' => {{BEHATFIREFOXCAPABILITIES}},
     ],
 ];
 

--- a/src/Bridge/MoodleConfig.php
+++ b/src/Bridge/MoodleConfig.php
@@ -32,25 +32,31 @@ class MoodleConfig
      */
     public function createContents(AbstractDatabase $database, string $dataDir): string
     {
-        $template  = file_get_contents(__DIR__ . '/../../res/template/config.php.txt');
-        $variables = [
-            '{{DBTYPE}}'              => $database->type,
-            '{{DBLIBRARY}}'           => $database->library,
-            '{{DBHOST}}'              => $database->host,
-            '{{DBPORT}}'              => $database->port,
-            '{{DBNAME}}'              => $database->name,
-            '{{DBUSER}}'              => $database->user,
-            '{{DBPASS}}'              => $database->pass,
-            '{{WWWROOT}}'             => 'http://localhost/moodle',
-            '{{DATAROOT}}'            => $dataDir,
-            '{{PHPUNITDATAROOT}}'     => $dataDir . '/phpu_moodledata',
-            '{{BEHATDATAROOT}}'       => $dataDir . '/behat_moodledata',
-            '{{BEHATDUMP}}'           => $dataDir . '/behat_dump',
-            '{{BEHATWWWROOT}}'        => getenv('MOODLE_BEHAT_WWWROOT') ?: 'http://localhost:8000',
-            '{{BEHATWDHOST}}'         => getenv('MOODLE_BEHAT_WDHOST') ?: 'http://localhost:4444/wd/hub',
-            '{{BEHATDEFAULTBROWSER}}' => getenv('MOODLE_BEHAT_DEFAULT_BROWSER') ?: (getenv('MOODLE_APP') ? 'chrome' : 'firefox'),
-            '{{BEHATIONICWWWROOT}}'   => getenv('MOODLE_APP') ? 'http://localhost:8100' : (getenv('MOODLE_BEHAT_IONIC_WWWROOT') ?: ''),
-            '{{EXTRACONFIG}}'         => self::PLACEHOLDER,
+        $template                 = file_get_contents(__DIR__ . '/../../res/template/config.php.txt');
+        $behatdefaultbrowser      = getenv('MOODLE_BEHAT_DEFAULT_BROWSER') ?: (getenv('MOODLE_APP') ? 'chrome' : 'firefox');
+        $behatchromecapabilities  = getenv('MOODLE_BEHAT_CHROME_CAPABILITIES') ?: '[]';
+        $behatfirefoxcapabilities = getenv('MOODLE_BEHAT_FIREFOX_CAPABILITIES') ?: '[]';
+        $variables                = [
+            '{{DBTYPE}}'                   => $database->type,
+            '{{DBLIBRARY}}'                => $database->library,
+            '{{DBHOST}}'                   => $database->host,
+            '{{DBPORT}}'                   => $database->port,
+            '{{DBNAME}}'                   => $database->name,
+            '{{DBUSER}}'                   => $database->user,
+            '{{DBPASS}}'                   => $database->pass,
+            '{{WWWROOT}}'                  => 'http://localhost/moodle',
+            '{{DATAROOT}}'                 => $dataDir,
+            '{{PHPUNITDATAROOT}}'          => $dataDir . '/phpu_moodledata',
+            '{{BEHATDATAROOT}}'            => $dataDir . '/behat_moodledata',
+            '{{BEHATDUMP}}'                => $dataDir . '/behat_dump',
+            '{{BEHATWWWROOT}}'             => getenv('MOODLE_BEHAT_WWWROOT') ?: 'http://localhost:8000',
+            '{{BEHATWDHOST}}'              => getenv('MOODLE_BEHAT_WDHOST') ?: 'http://localhost:4444/wd/hub',
+            '{{BEHATDEFAULTBROWSER}}'      => $behatdefaultbrowser,
+            '{{BEHATIONICWWWROOT}}'        => getenv('MOODLE_APP') ? 'http://localhost:8100' : (getenv('MOODLE_BEHAT_IONIC_WWWROOT') ?: ''),
+            '{{BEHATDEFAULTCAPABILITIES}}' => $behatdefaultbrowser === 'chrome' ? $behatchromecapabilities : $behatfirefoxcapabilities,
+            '{{BEHATCHROMECAPABILITIES}}'  => $behatchromecapabilities,
+            '{{BEHATFIREFOXCAPABILITIES}}' => $behatfirefoxcapabilities,
+            '{{EXTRACONFIG}}'              => self::PLACEHOLDER,
         ];
 
         return str_replace(array_keys($variables), array_values($variables), $template);

--- a/tests/Bridge/MoodleConfigTest.php
+++ b/tests/Bridge/MoodleConfigTest.php
@@ -18,12 +18,38 @@ use MoodlePluginCI\Tests\FilesystemTestCase;
 
 class MoodleConfigTest extends FilesystemTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('MOODLE_BEHAT_CHROME_CAPABILITIES=');
+        putenv('MOODLE_BEHAT_FIREFOX_CAPABILITIES=');
+    }
+
     public function testCreateContents()
     {
         $config   = new MoodleConfig();
         $contents = $config->createContents(new MySQLDatabase(), '/path/to/moodledata');
 
         $this->assertSame(file_get_contents(__DIR__ . '/../Fixture/example-config.php'), $contents);
+    }
+
+    public function testConfigureChromeBrowserCapabilities()
+    {
+        putenv("MOODLE_BEHAT_CHROME_CAPABILITIES=['extra_capabilities'=>['chromeOptions'=>['args'=>['--ignore-certificate-errors','--allow-running-insecure-content']]]]");
+        $config   = new MoodleConfig();
+        $contents = $config->createContents(new MySQLDatabase(), '/path/to/moodledata');
+
+        $this->assertSame(file_get_contents(__DIR__ . '/../Fixture/example-config-with-chrome-capabilities.php'), $contents);
+    }
+
+    public function testConfigureFirefoxBrowserCapabilities()
+    {
+        putenv("MOODLE_BEHAT_FIREFOX_CAPABILITIES=['extra_capabilities'=>['firefoxOptions'=>['args'=>['-headless']]]]");
+        $config   = new MoodleConfig();
+        $contents = $config->createContents(new MySQLDatabase(), '/path/to/moodledata');
+
+        $this->assertSame(file_get_contents(__DIR__ . '/../Fixture/example-config-with-firefox-capabilities.php'), $contents);
     }
 
     public function testInjectLineIntoConfig()

--- a/tests/Fixture/example-config-with-chrome-capabilities.php
+++ b/tests/Fixture/example-config-with-chrome-capabilities.php
@@ -50,7 +50,7 @@ $CFG->behat_profiles      = [
     'chrome' => [
         'browser'      => 'chrome',
         'wd_host'      => 'http://localhost:4444/wd/hub',
-        'capabilities' => [],
+        'capabilities' => ['extra_capabilities'=>['chromeOptions'=>['args'=>['--ignore-certificate-errors','--allow-running-insecure-content']]]],
     ],
     'firefox' => [
         'browser'      => 'firefox',

--- a/tests/Fixture/example-config-with-firefox-capabilities.php
+++ b/tests/Fixture/example-config-with-firefox-capabilities.php
@@ -45,7 +45,7 @@ $CFG->behat_profiles      = [
     'default' => [
         'browser'      => 'firefox',
         'wd_host'      => 'http://localhost:4444/wd/hub',
-        'capabilities' => [],
+        'capabilities' => ['extra_capabilities'=>['firefoxOptions'=>['args'=>['-headless']]]],
     ],
     'chrome' => [
         'browser'      => 'chrome',
@@ -55,7 +55,7 @@ $CFG->behat_profiles      = [
     'firefox' => [
         'browser'      => 'firefox',
         'wd_host'      => 'http://localhost:4444/wd/hub',
-        'capabilities' => [],
+        'capabilities' => ['extra_capabilities'=>['firefoxOptions'=>['args'=>['-headless']]]],
     ],
 ];
 


### PR DESCRIPTION
I have tried using the [add-config](https://moodlehq.github.io/moodle-plugin-ci/AddExtraConfig.html) command to achieve this instead, but it seems like the Behat configuration is created in the `install` command so changes done afterwards are not applied. And if I try to use the `add-config` command before installing, I get an error.

So the only solution I've found is to modify `config.php.txt` before running the `install` command, but that's a bit fickle so it would be nice to have an idiomatic way to achieve it.