### PR TITLE
Show a warning annotation when "master" branch usage is detected

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,14 +9,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-
 ### Changed
 - Updated all uses of `actions/checkout` from `v3` (using node 16) to `v4` (using node 20), because [actions using node 16 are deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and will stop working in the future.
-* ACTION SUGGESTED: In order to avoid the node 16 deprecation warnings, update your workflows to use `actions/checkout@v4`.
+- ACTION SUGGESTED: In order to avoid the node 16 deprecation warnings, update your workflows to use `actions/checkout@v4`.
 
 ### Deprecated
 - The `phpcpd` command (that uses the [PHP Copy/Paste Detector](https://github.com/sebastianbergmann/phpcpd), now abandoned) has been deprecated in this `moodle-plugin-ci` release (4.4.0) and will be removed in 5.0.0. No replacement is planned.
 - ACTION SUGGESTED: In order to avoid deprecation warnings or annotations, proceed to remove this command from your workflows. Note that any use will throw an error in the next major release (5.0.0).
+- The `master` branch of Moodle upstream repositories has been moved to `main` and will stop working soon (see [MDLSITE-7418](https://tracker.moodle.org/browse/MDLSITE-7418) for details). GitHub workflows will start emitting warnings/annotations when uses of the `master` branch are detected.
+- ACTION SUGGESTED: In order to avoid deprecation warnings or annotations, proceed to replace `master` by `main` in your workflows. Note that any use of the former (to be removed) will throw an error in the future.
 
 ## [4.3.2] - 2024-01-26
 ### Changed

--- a/src/Command/CopyPasteDetectorCommand.php
+++ b/src/Command/CopyPasteDetectorCommand.php
@@ -38,6 +38,7 @@ class CopyPasteDetectorCommand extends AbstractPluginCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        // @codeCoverageIgnoreStart
         if (!defined('PHPUNIT_TEST')) { // Only show deprecation warnings in non-test environments.
             trigger_deprecation(
                 'moodle-plugin-ci',
@@ -51,6 +52,7 @@ class CopyPasteDetectorCommand extends AbstractPluginCommand
                     'is deprecated and will be removed in 5.0.0. No replacement is planned.' . PHP_EOL;
             }
         }
+        // @codeCoverageIgnoreEnd
 
         $timer = new Timer();
         $timer->start();

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -62,6 +62,17 @@ class InstallCommand extends Command
         $extra  = getenv('EXTRA_PLUGINS_DIR') !== false ? getenv('EXTRA_PLUGINS_DIR') : null;
         $node   = getenv('NODE_VERSION') !== false ? getenv('NODE_VERSION') : null;
 
+        // Emit a warning/annotation under GHA if the branch is master (recommending to move to main).
+        // @codeCoverageIgnoreStart
+        if (getenv('GITHUB_ACTIONS')) { // Only show annotations in GitHub Actions.
+            if ($branch === 'master') { // And only if the branch being used is master.
+                echo '::warning title=`master` branch use detected::The `master` branch of Moodle has been ' .
+                    'moved to `main` and will stop working soon. Please consider moving to `main` in your ' .
+                    'workflows. Ref.: MDLSITE-7418' . PHP_EOL;
+            }
+        }
+        // @codeCoverageIgnoreEnd
+
         // As there is not only Travis CI, it can also be passed a generic environment variable.
         if (null === $plugin) {
             $plugin = getenv('CI_BUILD_DIR') !== false ? getenv('CI_BUILD_DIR') : null;


### PR DESCRIPTION
That way, both the web UI and the email from GitHub will show the recommendation about to move to the new "main" branch.
    
Also, unrelated, exclude some unreachable code from code coverage analysis.

Here there is an example to show how the annotation looks like (at the bottom):

https://github.com/stronk7/moodle-plugin-ci/actions/runs/7812729398

Note that an unrelated 2nd commit has been added about to try to keep Travis working, because it has started to fail recently (maybe they changed the PostgreSQL ports again, grrr).
