### PR TITLE
Update App config defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,14 +77,19 @@ jobs:
         include:
           - php: '8.3'
             moodle-branch: 'main'
+            moodle-app: 'true'
           - php: '8.3'
             moodle-branch: 'MOODLE_404_STABLE'
+            moodle-app: 'true'
           - php: '8.2'
             moodle-branch: 'MOODLE_403_STABLE'
+            moodle-app: 'true'
           - php: '8.2'
             moodle-branch: 'MOODLE_402_STABLE'
+            moodle-app: 'true'
           - php: '8.1'
             moodle-branch: 'MOODLE_401_STABLE'
+            moodle-app: 'true'
           - php: '8.0'
             moodle-branch: 'MOODLE_400_STABLE'
           - php: '8.0'
@@ -126,7 +131,7 @@ jobs:
         IGNORE_PATHS: 'ignore'
         IGNORE_NAMES: 'ignore_name.php'
         MUSTACHE_IGNORE_NAMES: 'broken.mustache'
-        MOODLE_APP: 'true'
+        MOODLE_APP: ${{ matrix.moodle-app }}
 
     - name: Run Integration tests
       env:
@@ -196,14 +201,19 @@ jobs:
           # Each supported PHP version once. That's enough.
           - php: '8.3'
             moodle-branch: 'main'
+            moodle-app: 'true'
           - php: '8.3'
             moodle-branch: 'MOODLE_404_STABLE'
+            moodle-app: 'true'
           - php: '8.2'
             moodle-branch: 'MOODLE_403_STABLE'
+            moodle-app: 'true'
           - php: '8.1'
             moodle-branch: 'MOODLE_402_STABLE'
+            moodle-app: 'true'
           - php: '8.0'
             moodle-branch: 'MOODLE_401_STABLE'
+            moodle-app: 'true'
           - php: '7.4'
             moodle-branch: 'MOODLE_400_STABLE'
 
@@ -245,7 +255,7 @@ jobs:
         IGNORE_PATHS: 'ignore'
         IGNORE_NAMES: 'ignore_name.php'
         MUSTACHE_IGNORE_NAMES: 'broken.mustache'
-        MOODLE_APP: 'true'
+        MOODLE_APP: ${{ matrix.moodle-app }}
 
     - name: Run Integration tests (PHAR)
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
     fi
 
 install:
-  - MOODLE_APP=true moodle-plugin-ci install -vvv
+  - moodle-plugin-ci install -vvv
 
 script:
   # This is basically "integration" testing.
@@ -91,10 +91,14 @@ jobs:
       if: env(MOODLE_BRANCH) IS present
     # Only main with highest supported PHP version.
     - php: 8.3
-      env: MOODLE_BRANCH=main
+      env:
+        - MOODLE_BRANCH=main
+        - MOODLE_APP=true
     # Last stable with highest supported PHP version.
     - php: 8.3
-      env: MOODLE_BRANCH=MOODLE_404_STABLE
+      env:
+        - MOODLE_BRANCH=MOODLE_404_STABLE
+        - MOODLE_APP=true
     # And older stable supported (with lowest supported PHP version).
     - php: 7.4
       env: MOODLE_BRANCH=MOODLE_39_STABLE

--- a/docs/MoodleApp.md
+++ b/docs/MoodleApp.md
@@ -11,7 +11,9 @@ In practice, you only need to set the `MOODLE_APP` env variable to `true`, and a
 - `MOODLE_APP_BEHAT_PLUGIN_PROJECT`: Project in github to use for installing the plugin with Behat steps specific to the Moodle App. The default value is `moodlehq/moodle-local_moodleappbehat`. This variable will be ignored if `MOODLE_APP_BEHAT_PLUGIN_REPOSITORY` is set.
 - `MOODLE_APP_BEHAT_PLUGIN_REPOSITORY`: Repository url to use for installing the plugin with Behat steps specific to the Moodle App. By default, the github repository defined in `MOODLE_APP_BEHAT_PLUGIN_PROJECT` will be used.
 - `MOODLE_APP_BEHAT_PLUGIN_BRANCH`: Branch of the repository to use for installing the plugin with Behat steps specific to the Moodle App. The default value is `latest`.
-- `MOODLE_BEHAT_IONIC_WWWROOT`: Value to use in `$CFG->behat_ionic_wwwroot`. The default value is `http://localhost:8100`. This value should only be used if `MOODLE_APP` is not set, and the Moodle App dependencies are configured manually.
+- `MOODLE_APP_PORT`: Port to listen in the Docker image. The default value is `443`, but you may need to set it to `80` for older versions of the app.
+- `MOODLE_APP_PROTOCOL`: Protocol to use when interaction with the app. The default value is `https`, but you may need to set it to `http` for older versions of the app.
+- `MOODLE_BEHAT_IONIC_WWWROOT`: Value to use in `$CFG->behat_ionic_wwwroot`. The default value is `https://localhost:8100` (or `http://localhost:8100` if `MOODLE_APP_PROTOCOL` is set to `http`). This value should only be used if `MOODLE_APP` is not set, and the Moodle App dependencies are configured manually.
 
 Finally, keep in mind that mobile tests only run on Chrome, so make sure that you're using the correct browser. If you're setting the `MOODLE_APP` variable, the default browser should already be Chrome; but you can set it explicitly using the `--profile` flag otherwise.
 

--- a/src/Bridge/MoodleConfig.php
+++ b/src/Bridge/MoodleConfig.php
@@ -32,10 +32,14 @@ class MoodleConfig
      */
     public function createContents(AbstractDatabase $database, string $dataDir): string
     {
+        $chromeinsecureargs         = "['--ignore-certificate-errors', '--allow-running-insecure-content']";
+        $chromeinsecurecapabilities = "['extra_capabilities' => ['chromeOptions' => ['args' => $chromeinsecureargs]]]";
+
         $template                 = file_get_contents(__DIR__ . '/../../res/template/config.php.txt');
         $behatdefaultbrowser      = getenv('MOODLE_BEHAT_DEFAULT_BROWSER') ?: (getenv('MOODLE_APP') ? 'chrome' : 'firefox');
-        $behatchromecapabilities  = getenv('MOODLE_BEHAT_CHROME_CAPABILITIES') ?: '[]';
+        $behatchromecapabilities  = getenv('MOODLE_BEHAT_CHROME_CAPABILITIES') ?: (getenv('MOODLE_APP') ? $chromeinsecurecapabilities : '[]');
         $behatfirefoxcapabilities = getenv('MOODLE_BEHAT_FIREFOX_CAPABILITIES') ?: '[]';
+        $appprotocol              = getenv('MOODLE_APP_PROTOCOL') ?: 'https';
         $variables                = [
             '{{DBTYPE}}'                   => $database->type,
             '{{DBLIBRARY}}'                => $database->library,
@@ -52,7 +56,7 @@ class MoodleConfig
             '{{BEHATWWWROOT}}'             => getenv('MOODLE_BEHAT_WWWROOT') ?: 'http://localhost:8000',
             '{{BEHATWDHOST}}'              => getenv('MOODLE_BEHAT_WDHOST') ?: 'http://localhost:4444/wd/hub',
             '{{BEHATDEFAULTBROWSER}}'      => $behatdefaultbrowser,
-            '{{BEHATIONICWWWROOT}}'        => getenv('MOODLE_APP') ? 'http://localhost:8100' : (getenv('MOODLE_BEHAT_IONIC_WWWROOT') ?: ''),
+            '{{BEHATIONICWWWROOT}}'        => getenv('MOODLE_APP') ? "$appprotocol://localhost:8100" : (getenv('MOODLE_BEHAT_IONIC_WWWROOT') ?: ''),
             '{{BEHATDEFAULTCAPABILITIES}}' => $behatdefaultbrowser === 'chrome' ? $behatchromecapabilities : $behatfirefoxcapabilities,
             '{{BEHATCHROMECAPABILITIES}}'  => $behatchromecapabilities,
             '{{BEHATFIREFOXCAPABILITIES}}' => $behatfirefoxcapabilities,

--- a/src/Command/BehatCommand.php
+++ b/src/Command/BehatCommand.php
@@ -212,7 +212,7 @@ class BehatCommand extends AbstractMoodleCommand
         }
 
         if ($profile === 'chrome') {
-            return 'selenium/standalone-chrome:3';
+            return getenv('MOODLE_APP') ? 'selenium/standalone-chrome:120.0' : 'selenium/standalone-chrome:3';
         }
 
         if ($this->usesLegacyPhpWebdriver()) {

--- a/src/Installer/MoodleAppInstaller.php
+++ b/src/Installer/MoodleAppInstaller.php
@@ -39,6 +39,7 @@ class MoodleAppInstaller extends AbstractInstaller
         $this->getOutput()->step('Launch Moodle App docker image');
 
         $image = getenv('MOODLE_APP_DOCKER_IMAGE') ?: 'moodlehq/moodleapp:latest-test';
+        $port  = getenv('MOODLE_APP_PORT') ?: '443';
 
         $this->execute->mustRun([
             'docker',
@@ -47,7 +48,7 @@ class MoodleAppInstaller extends AbstractInstaller
             '--rm',
             '--name=moodleapp',
             '-p',
-            '8100:80',
+            "8100:$port",
             $image,
         ]);
 


### PR DESCRIPTION
I'm opening this PR as a draft because until v4.4.0 of the app is released, these defaults don't work with the `moodlehq/moodleapp:latest-test` image, which is the default (they only work with `moodlehq/moodleapp:next-test`). But we can get the review started so that once 4.4.0 is released, we can merge this.

`moodle-docker` has a similar issue, but given that we explicitly support different versions, I've implemented an interim solution in https://github.com/moodlehq/moodle-docker/pull/281.

But for `moodle-plugin-ci`, I think it's fine just to support one version out of the box. And anyone can configure old versions if they want using other env variables (the documentation has also been updated).