### PR TITLE
Adjust the Travis tests to current php and moodle versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,11 +90,11 @@ jobs:
     - stage: Integration tests
       if: env(MOODLE_BRANCH) IS present
     # Only main with highest supported PHP version.
-    - php: 8.2
+    - php: 8.3
       env: MOODLE_BRANCH=main
     # Last stable with highest supported PHP version.
     - php: 8.2
-      env: MOODLE_BRANCH=MOODLE_402_STABLE
+      env: MOODLE_BRANCH=MOODLE_403_STABLE
     # And older stable supported (with lowest supported PHP version).
     - php: 7.4
       env: MOODLE_BRANCH=MOODLE_39_STABLE


### PR DESCRIPTION
Not much to say, let's verify that:

- The dev branch (main) works with its highest supported PHP version (8.3).
- The latest stable branch (403_STABLE) works with its highest supported PHP version (8.2).
- The oldest stable branch (39_STABLE) works with the lowest supported PHP version (7.4).

Link to travis PR run: https://app.travis-ci.com/github/moodlehq/moodle-plugin-ci/builds/269415755