### PR TITLE
Remove phpcpd (deprecated) from dist and explain docs

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -51,7 +51,6 @@ install:
 
 script:
   - moodle-plugin-ci phplint
-  - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
   - moodle-plugin-ci phpcs --max-warnings 0
   - moodle-plugin-ci phpdoc --max-warnings 0

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -142,11 +142,6 @@ jobs:
         if: ${{ !cancelled() }} # prevents CI run stopping if step failed.
         run: moodle-plugin-ci phplint
 
-      - name: PHP Copy/Paste Detector # DEPRECATED
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ !cancelled() }}
-        run: moodle-plugin-ci phpcpd
-
       - name: PHP Mess Detector
         continue-on-error: true
         if: ${{ !cancelled() }}

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -129,10 +129,6 @@ install:
 script:
 # This step lints your PHP files to check for syntax errors.
   - moodle-plugin-ci phplint
-# This step runs the PHP Copy/Paste Detector on your plugin.
-# This helps to find code duplication.
-# (DEPRECATED)
-  - moodle-plugin-ci phpcpd
 # This step runs the PHP Mess Detector on your plugin. This helps to find
 # potential problems with your code which can result in
 # refactoring opportunities.

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -70,11 +70,6 @@ jobs:
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci phplint
 
-      - name: PHP Copy/Paste Detector
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ !cancelled() }}
-        run: moodle-plugin-ci phpcpd
-
       - name: PHP Mess Detector
         continue-on-error: true # This step will show errors but will not fail
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Better stop having the deprecated phpcpd command available in the dist and explain docs, so newcomers won't enable it by default. It's going to be removed in v5.

Part of #262, credit goes to @jrchamp