### PR TITLE
Add step for Behat faildump storing as GHA artifact.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+
+- Added GHA step to store Behat faildump as workflow artefact, so it can be
+  [inspected](https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts). Documentation has been updated as well to reflect the purpose of the step.
+
 ## [4.4.1] - 2024-03-08
 ### Added
 - New `--no-plugin-node` option added to the `install` command, to be able to skip the installation of any NodeJS stuff that the plugin may include. The previous default has not changed and both Moodle's and plugin's NodeJS installation continues happening normally.

--- a/docs/GHAFileExplained.md
+++ b/docs/GHAFileExplained.md
@@ -181,8 +181,21 @@ jobs:
         run: moodle-plugin-ci phpunit
 
       - name: Behat features
+        id: behat
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci behat --profile chrome
+
+      # This step allows to upload Behat faildump (screenshots) as workflow artifact
+      # so it can be downloaded and inspected. You don't need this step if you
+      # are not running Behat test. Artifact will be retained for 7 days.
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump (${{ join(matrix.*, ', ') }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Mark cancelled jobs as failed.
         if: ${{ cancelled() }}

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -109,8 +109,18 @@ jobs:
         run: moodle-plugin-ci phpunit --fail-on-warning
 
       - name: Behat features
+        id: behat
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci behat --profile chrome
+
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump (${{ join(matrix.*, ', ') }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Mark cancelled jobs as failed.
         if: ${{ cancelled() }}


### PR DESCRIPTION
Add GHA step to store Behat faildump as workflow artifact, so it can be [inspected](https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts).

![image](https://github.com/moodlehq/moodle-plugin-ci/assets/329780/7a944c04-40b0-4ad0-8ef2-4d0cb257a062)

This step will be run only if Behat step failed (see `if` statement). It also configured not to produce warning if files are not found (the cause of Behat error might be not the actual test scenario). Name is derived from the job matrix, it needs to be unique per job when matrix is used (artifact upload will fail on name conflict if more than 1 job will fail on Behat)

Demo (simplified for speed):
* Failed job: https://github.com/kabalin/moodle-format_flexsections/actions/runs/8307608604
* Succeeded job (no artifacts): https://github.com/kabalin/moodle-format_flexsections/actions/runs/8307723810

More info on upload artifact: https://github.com/actions/upload-artifact