### PR TITLE
Deprecate the phpdbg option for code coverage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Deprecated
+- The use of `phpdbg` to calculate PHPUnit's code-coverage has been deprecated in this `moodle-plugin-ci` release (4.5.0) and will be removed in 5.0.0. This includes both the implicit (default) option when no alternative (`pcov` or `xdebug`) is available and the explicit `--coverage-phpdbg` option.
+- ACTION SUGGESTED: In order to avoid deprecation warnings or annotations, proceed to ensure that either `pcov` (Moodle 3.10 and up) or `xdebug` are available and they will be used automatically. Note that any use of `phpdbg` will throw an error in the next major release (5.0.0).
+
+### Fixed
+- Solved a problem with the validation of `dataformat` plugin lang strings.
 
 ## [4.4.5] - 2024-04-03
 ### Changed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -2133,7 +2133,7 @@ Use the xdebug extension to calculate code coverage
 
 #### `--coverage-phpdbg`
 
-Use the phpdbg binary to calculate code coverage
+(**DEPRECATED**) Use the phpdbg binary to calculate code coverage
 
 * Accept value: no
 * Is value required: no

--- a/src/Command/PHPUnitCommand.php
+++ b/src/Command/PHPUnitCommand.php
@@ -47,7 +47,7 @@ class PHPUnitCommand extends AbstractMoodleCommand
             ->addOption('coverage-clover', null, InputOption::VALUE_NONE, 'Generate code coverage report in Clover XML format')
             ->addOption('coverage-pcov', null, InputOption::VALUE_NONE, 'Use the pcov extension to calculate code coverage')
             ->addOption('coverage-xdebug', null, InputOption::VALUE_NONE, 'Use the xdebug extension to calculate code coverage')
-            ->addOption('coverage-phpdbg', null, InputOption::VALUE_NONE, 'Use the phpdbg binary to calculate code coverage')
+            ->addOption('coverage-phpdbg', null, InputOption::VALUE_NONE, '(**DEPRECATED**) Use the phpdbg binary to calculate code coverage')
             ->addOption('fail-on-incomplete', null, InputOption::VALUE_NONE, 'Treat incomplete tests as failures')
             ->addOption('fail-on-risky', null, InputOption::VALUE_NONE, 'Treat risky tests as failures')
             ->addOption('fail-on-skipped', null, InputOption::VALUE_NONE, 'Treat skipped tests as failures')
@@ -195,6 +195,15 @@ class PHPUnitCommand extends AbstractMoodleCommand
                     '-dxdebug.mode=coverage',
                 ];
             case 'phpdbg':
+                // @codeCoverageIgnoreStart
+                if (!defined('PHPUNIT_TEST')) { // Only show deprecation warnings in non-test environments.
+                    if (getenv('GITHUB_ACTIONS')) { // Only show deprecation annotations in GitHub Actions.
+                        echo '::warning title=Deprecated phpdbg option::The use of phpdbg for phpunit code coverage ' .
+                            'is deprecated and will be removed in 5.0.0. Please, switch to pcov or xdebug instead.' . PHP_EOL;
+                    }
+                }
+                // @codeCoverageIgnoreEnd
+
                 return [
                     'phpdbg',
                     '-d',


### PR DESCRIPTION
This includes both the current default (when neither pcov or xdebug are available) and the explicit use of --coverage-phpdbg

Since PHP 8.0, phpdbg is causing all sort of problems and is not recommended. So it's time to deprecate it in order to proceed to remove it completely for moodle-plugin-ci 5.0.0.

Removal ref.: https://github.com/moodlehq/moodle-plugin-ci/issues/289

Fixes #213