### PR TITLE
Add support for MSSQL

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -917,7 +917,7 @@ Path to Moodle plugin
 
 #### `--db-type`
 
-Database type, mysqli, pgsql or mariadb
+Database type, mysqli, pgsql, mariadb or sqrsrv
 
 * Accept value: yes
 * Is value required: yes

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -27,12 +27,21 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
 
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2019-CU25-ubuntu-20.04
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: 'RequiredPassw0rd!'
+        ports:
+          - 1433:1433
+        options: --health-cmd="/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P RequiredPassw0rd! -Q \"SELECT 1\" -b -o /dev/null" --health-interval 10s --health-timeout 5s --health-retries 10
+
     strategy:
       fail-fast: false
       matrix:
         php: ['7.4', '8.0', '8.1']
         moodle-branch: ['MOODLE_401_STABLE']
-        database: [pgsql, mariadb]
+        database: [pgsql, mariadb, sqlsrv]
 
     steps:
       - name: Check out repository code
@@ -44,7 +53,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.extensions }}
+          extensions: sqlsrv
           ini-values: max_input_vars=5000
           # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
           # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
@@ -59,7 +68,7 @@ jobs:
           echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
 
       - name: Install moodle-plugin-ci
-        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1 ${{ matrix.database == 'sqlsrv' && '--db-pass=RequiredPassw0rd!' || '' }}
         env:
           DB: ${{ matrix.database }}
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -92,7 +92,7 @@ class InstallCommand extends Command
             ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'Moodle repository to clone', $repo)
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Moodle git branch to clone, EG: MOODLE_29_STABLE', $branch)
             ->addOption('plugin', null, InputOption::VALUE_REQUIRED, 'Path to Moodle plugin', $plugin)
-            ->addOption('db-type', null, InputOption::VALUE_REQUIRED, 'Database type, mysqli, pgsql or mariadb', $type)
+            ->addOption('db-type', null, InputOption::VALUE_REQUIRED, 'Database type, mysqli, pgsql, mariadb or sqlsrv', $type)
             ->addOption('db-user', null, InputOption::VALUE_REQUIRED, 'Database user', $dbUser)
             ->addOption('db-pass', null, InputOption::VALUE_REQUIRED, 'Database pass', $dbPass)
             ->addOption('db-name', null, InputOption::VALUE_REQUIRED, 'Database name', $dbName)

--- a/src/Installer/Database/DatabaseResolver.php
+++ b/src/Installer/Database/DatabaseResolver.php
@@ -65,7 +65,7 @@ class DatabaseResolver
                 return $database;
             }
         }
-        throw new \DomainException(sprintf('Unknown database type (%s). Please use mysqli, pgsql or mariadb.', $type));
+        throw new \DomainException(sprintf('Unknown database type (%s). Please use mysqli, pgsql, mariadb or sqlsrv.', $type));
     }
 
     /**
@@ -73,6 +73,6 @@ class DatabaseResolver
      */
     private function getDatabases(): array
     {
-        return [new MySQLDatabase(), new PostgresDatabase(), new MariaDBDatabase()];
+        return [new MySQLDatabase(), new PostgresDatabase(), new MariaDBDatabase(), new MSSQLDatabase()];
     }
 }

--- a/src/Installer/Database/MSSQLDatabase.php
+++ b/src/Installer/Database/MSSQLDatabase.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2024 Justus Dieckmann
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace MoodlePluginCI\Installer\Database;
+
+/**
+ * MSSQL Database.
+ */
+class MSSQLDatabase extends AbstractDatabase
+{
+    public string $user = 'sa';
+    public string $type = 'sqlsrv';
+
+    public function getCreateDatabaseCommand(): array
+    {
+        $host = $this->host;
+        if (!empty($this->port)) {
+            $host .= ",$this->port";
+        }
+
+        return array_filter([
+            'sqlcmd',
+            '-U',
+            $this->user,
+            !empty($this->pass) ? '-P' : '',
+            !empty($this->pass) ? $this->pass : '',
+            '-S',
+            $host,
+            '-Q',
+            sprintf('CREATE DATABASE %s COLLATE Latin1_General_CI_AI;', $this->name),
+        ]);
+    }
+}

--- a/tests/Installer/Database/DatabaseResolverTest.php
+++ b/tests/Installer/Database/DatabaseResolverTest.php
@@ -32,6 +32,11 @@ class DatabaseResolverTest extends \PHPUnit\Framework\TestCase
             'MoodlePluginCI\Installer\Database\MariaDBDatabase',
             $resolver->resolveDatabase('mariadb')
         );
+
+        $this->assertInstanceOf(
+            'MoodlePluginCI\Installer\Database\MSSQLDatabase',
+            $resolver->resolveDatabase('sqlsrv')
+        );
     }
 
     public function testTypeError()

--- a/tests/Installer/Database/MSSQLDatabaseTest.php
+++ b/tests/Installer/Database/MSSQLDatabaseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Moodle Plugin CI package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2024 Justus Dieckmann
+ * License http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace MoodlePluginCI\Tests\Installer\Database;
+
+use MoodlePluginCI\Installer\Database\MSSQLDatabase;
+
+class MSSQLDatabaseTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetCreateDatabaseCommand()
+    {
+        $database       = new MSSQLDatabase();
+        $database->name = 'TestName';
+        $database->user = 'TestUser';
+        $database->pass = 'TestPass';
+        $database->host = 'TestHost';
+
+        $expected = 'sqlcmd -U TestUser -P TestPass -S TestHost -Q CREATE DATABASE TestName COLLATE Latin1_General_CI_AI;';
+        $this->assertSame($expected, implode(' ', $database->getCreateDatabaseCommand()));
+    }
+}


### PR DESCRIPTION
Hey everyone,

this PR adds support for MSSQL (Fixes #92)

I tested it with our plugin tool_lifecycle [here](https://github.com/justusdieckmann/moodle-tool_lifecycle/commits/test/mssql/?since=2024-05-03&until=2024-05-03). The errors in the first commit are correct, since we used some MSSQL-incompatible syntax in the plugin. Those were addressed in the next two commits.

Justus