### PR TITLE
Make Moodle Install Clone step optional

### DIFF
--- a/src/Installer/MoodleInstaller.php
+++ b/src/Installer/MoodleInstaller.php
@@ -66,7 +66,9 @@ class MoodleInstaller extends AbstractInstaller
             $this->moodle->directory,
         ];
 
-        $this->execute->mustRun(new Process($cmd, null, null, null, null));
+        if (!is_dir($this->moodle->directory)) {
+            $this->execute->mustRun(new Process($cmd, null, null, null, null));
+        }
 
         // Expand the path to Moodle so all other installers use absolute path.
         $this->moodle->directory = $this->expandPath($this->moodle->directory);

--- a/src/Installer/MoodleInstaller.php
+++ b/src/Installer/MoodleInstaller.php
@@ -66,6 +66,7 @@ class MoodleInstaller extends AbstractInstaller
             $this->moodle->directory,
         ];
 
+        // Only run git clone if it does not already exist
         if (!is_dir($this->moodle->directory)) {
             $this->execute->mustRun(new Process($cmd, null, null, null, null));
         }


### PR DESCRIPTION
I would like to propose that we make the `git clone` step of Moodle install an optional step.

The Rational behind this is we have a custom docker image that runs our tests on Gitlab when we push code. We would like to bake Moodle itself into the docker image. Baking in moodle, and then running `moodle-plugin-ci install --moodle /moodle`.

This does 2 main things
1. Speed up the test process by not having to do a fresh git clone every time a test runs.
2. Reduces load on our Gitlab server (where our Moodle fork lives), by not doing clones all the time

As it checks for if the folder exists, it will run like it does now if the folder does not exist, having no impact on people already using it.

Doing this approach allows actions to cache the location of the install, so repeated runs can all run the same command, and if the cache has been cleared it will run the `git clone` command, and if the cache exists the step will just be skipped