### PR TITLE
Use general stylelint task in grunt command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Fixed stylelinting error in non-theme plugins containing scss.
+
+### Removed
+- Stylelint less component task (`grunt stylelint:less`) has been deprecated in
+  Moodle 3.7.
+
 ## [4.5.4] - 2024-08-23
 ### Changed
 - Fixed nvm loading issue caused by upstream regression.

--- a/src/Command/GruntCommand.php
+++ b/src/Command/GruntCommand.php
@@ -33,7 +33,7 @@ class GruntCommand extends AbstractMoodleCommand
     {
         parent::configure();
 
-        $tasks = ['amd', 'yui', 'gherkinlint', 'stylelint:css', 'stylelint:less', 'stylelint:scss'];
+        $tasks = ['amd', 'yui', 'gherkinlint', 'stylelint:css', 'stylelint:scss'];
 
         $this->setName('grunt')
             ->setDescription('Run Grunt task on a plugin')
@@ -196,8 +196,6 @@ class GruntCommand extends AbstractMoodleCommand
                 return new GruntTaskModel($task, $this->moodle->directory);
             case 'stylelint:css':
                 return $this->plugin->hasFilesWithName('*.css') ? $defaultTaskPluginDir : null;
-            case 'stylelint:less':
-                return $this->plugin->hasFilesWithName('*.less') ? $defaultTaskPluginDir : null;
             case 'stylelint:scss':
                 return $this->plugin->hasFilesWithName('*.scss') ? $defaultTaskPluginDir : null;
             default:

--- a/src/Command/GruntCommand.php
+++ b/src/Command/GruntCommand.php
@@ -33,7 +33,7 @@ class GruntCommand extends AbstractMoodleCommand
     {
         parent::configure();
 
-        $tasks = ['amd', 'yui', 'gherkinlint', 'stylelint:css', 'stylelint:scss'];
+        $tasks = ['amd', 'yui', 'gherkinlint', 'stylelint'];
 
         $this->setName('grunt')
             ->setDescription('Run Grunt task on a plugin')
@@ -194,6 +194,9 @@ class GruntCommand extends AbstractMoodleCommand
                 }
 
                 return new GruntTaskModel($task, $this->moodle->directory);
+            case 'stylelint':
+                // Let stylelint task logic to determine which type of linter to run.
+                return $this->plugin->hasFilesWithName('*.css') || $this->plugin->hasFilesWithName('*.scss') ? $defaultTaskPluginDir : null;
             case 'stylelint:css':
                 return $this->plugin->hasFilesWithName('*.css') ? $defaultTaskPluginDir : null;
             case 'stylelint:scss':

--- a/tests/Command/GruntCommandTest.php
+++ b/tests/Command/GruntCommandTest.php
@@ -145,7 +145,6 @@ class GruntCommandTest extends MoodleTestCase
         $this->fs->remove($this->pluginDir . '/styles.css');
 
         $this->assertNull($command->toGruntTask('stylelint:css'));
-        $this->assertNull($command->toGruntTask('stylelint:less'));
         $this->assertNull($command->toGruntTask('stylelint:scss'));
     }
 

--- a/tests/Command/GruntCommandTest.php
+++ b/tests/Command/GruntCommandTest.php
@@ -132,9 +132,15 @@ class GruntCommandTest extends MoodleTestCase
         $this->assertNull($command->toGruntTask('gherkinlint'));
     }
 
-    public function testToGruntTaskWithStyles()
+    public function testToGruntTaskWithStylesCss()
     {
         $command = $this->newCommand();
+
+        $task = $command->toGruntTask('stylelint');
+        $this->assertInstanceOf(GruntTaskModel::class, $task);
+        $this->assertSame('stylelint', $task->taskName);
+        $this->assertSame('', $task->buildDirectory);
+        $this->assertSame($this->pluginDir, $task->workingDirectory);
 
         $task = $command->toGruntTask('stylelint:css');
         $this->assertInstanceOf(GruntTaskModel::class, $task);
@@ -144,7 +150,31 @@ class GruntCommandTest extends MoodleTestCase
 
         $this->fs->remove($this->pluginDir . '/styles.css');
 
+        $this->assertNull($command->toGruntTask('stylelint'));
         $this->assertNull($command->toGruntTask('stylelint:css'));
+    }
+
+    public function testToGruntTaskWithStylesScss()
+    {
+        $command = $this->newCommand();
+        $this->fs->mkdir($this->pluginDir . '/scss');
+        $this->fs->rename($this->pluginDir . '/styles.css', $this->pluginDir . '/scss/styles.scss');
+
+        $task = $command->toGruntTask('stylelint');
+        $this->assertInstanceOf(GruntTaskModel::class, $task);
+        $this->assertSame('stylelint', $task->taskName);
+        $this->assertSame('', $task->buildDirectory);
+        $this->assertSame($this->pluginDir, $task->workingDirectory);
+
+        $task = $command->toGruntTask('stylelint:scss');
+        $this->assertInstanceOf(GruntTaskModel::class, $task);
+        $this->assertSame('stylelint:scss', $task->taskName);
+        $this->assertSame('', $task->buildDirectory);
+        $this->assertSame($this->pluginDir, $task->workingDirectory);
+
+        $this->fs->remove($this->pluginDir . '/scss');
+
+        $this->assertNull($command->toGruntTask('stylelint'));
         $this->assertNull($command->toGruntTask('stylelint:scss'));
     }
 


### PR DESCRIPTION
This change makes use of general stylelint task in grunt command, thus let grunt task to decide whether css or scss linter needs to be run (or both).

Also cleans up deprecated `stylelint:less` task (removed in 3.7 at MDL-64506) in a separate commit.

Fixes https://github.com/moodlehq/moodle-plugin-ci/issues/314
