### PR TITLE
Update to Postgres 14 as required by main

### DIFF
--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:14
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'


### PR DESCRIPTION
plugin installs against main branch of moodle are failing since the postgres 14 requirement has been integrated

```
  Output:                                                                      
  ================                                                             
  == Environment ==                                                            
  !! database postgres (13.18 (Debian 13.18-1.pgdg120+1)) !!                   
  [System] version 14 is required and you are running 13.18 -                  
```
                                                                     