### PR TITLE
Ignore missing class_alias call in filter validation for Moodle 4.5

### DIFF
--- a/src/PluginValidate/Requirements/FilterRequirements.php
+++ b/src/PluginValidate/Requirements/FilterRequirements.php
@@ -53,7 +53,7 @@ class FilterRequirements extends GenericRequirements
 
     public function getRequiredFunctionCalls(): array
     {
-        if ($this->moodleVersion <= 404 && !$this->fileExists('classes/text_filter.php')) {
+        if ($this->moodleVersion >= 405 || ($this->moodleVersion <= 404 && !$this->fileExists('classes/text_filter.php'))) {
             return [];
         }
 

--- a/tests/PluginValidate/Requirements/FilterRequirementsTest.php
+++ b/tests/PluginValidate/Requirements/FilterRequirementsTest.php
@@ -141,7 +141,9 @@ class FilterRequirementsTest extends \PHPUnit\Framework\TestCase
     public function testGetRequiredFunctionCalls()
     {
         $calls = $this->requirements->getRequiredFunctionCalls();
+        $this->assertCount(0, $calls);
 
+        $calls = $this->requirements404->getRequiredFunctionCalls();
         $this->assertCount(1, $calls);
         $call = reset($calls);
         $this->assertInstanceOf('MoodlePluginCI\PluginValidate\Finder\FileTokens', $call);


### PR DESCRIPTION
Closes #335 