### PR TITLE
Fix getComponentInstallDirectory plugintypes retrieval issue.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Fix getComponentInstallDirectory plugintypes retrieval issue to comply with 5.0
+
 ## [4.5.5] - 2024-11-06
 ### Added
 - Improvements to plugin validation implementation:

--- a/src/Bridge/Moodle.php
+++ b/src/Bridge/Moodle.php
@@ -106,11 +106,13 @@ class Moodle
         $method->setAccessible(true);
         $result = $method->invoke(null);
 
-        if (!array_key_exists($type, $result[0])) {
+        $plugintypes = $this->getBranch() >= 500 ? $result['plugintypes'] : $result[0];
+
+        if (!array_key_exists($type, $plugintypes)) {
             throw new \InvalidArgumentException(sprintf('The component %s has an unknown plugin type of %s', $component, $type));
         }
 
-        return $result[0][$type] . '/' . $name;
+        return $plugintypes[$type] . '/' . $name;
     }
 
     /**


### PR DESCRIPTION
`fetch_plugintypes` return signature was changed at [MDL-79843](https://tracker.moodle.org/browse/MDL-79843).