### PR TITLE
Add support for PHP 8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.3'
+          - php: '8.4'
             moodle-branch: 'main'
             moodle-app: 'true'
           - php: '8.3'
@@ -202,7 +202,7 @@ jobs:
       matrix:
         include:
           # Each supported PHP version once. That's enough.
-          - php: '8.3'
+          - php: '8.4'
             moodle-branch: 'main'
             moodle-app: 'true'
           - php: '8.3'
@@ -294,6 +294,7 @@ jobs:
       matrix:
         include:
           # Each supported PHP version once. That's enough.
+          - php: '8.4'
           - php: '8.3'
           - php: '8.2'
           - php: '8.1'

--- a/res/template/config.php.txt
+++ b/res/template/config.php.txt
@@ -22,7 +22,7 @@ $CFG->admin    = 'admin';
 $CFG->directorypermissions = 02777;
 
 // Show debugging messages.
-$CFG->debug        = (E_ALL | E_STRICT);
+$CFG->debug        = PHP_VERSION_ID >= 80000 ? E_ALL : E_ALL | E_STRICT;
 $CFG->debugdisplay = 1;
 
 // No emails.

--- a/tests/Fixture/example-config-with-chrome-capabilities.php
+++ b/tests/Fixture/example-config-with-chrome-capabilities.php
@@ -22,7 +22,7 @@ $CFG->admin    = 'admin';
 $CFG->directorypermissions = 02777;
 
 // Show debugging messages.
-$CFG->debug        = (E_ALL | E_STRICT);
+$CFG->debug        = PHP_VERSION_ID >= 80000 ? E_ALL : E_ALL | E_STRICT;
 $CFG->debugdisplay = 1;
 
 // No emails.

--- a/tests/Fixture/example-config-with-firefox-capabilities.php
+++ b/tests/Fixture/example-config-with-firefox-capabilities.php
@@ -22,7 +22,7 @@ $CFG->admin    = 'admin';
 $CFG->directorypermissions = 02777;
 
 // Show debugging messages.
-$CFG->debug        = (E_ALL | E_STRICT);
+$CFG->debug        = PHP_VERSION_ID >= 80000 ? E_ALL : E_ALL | E_STRICT;
 $CFG->debugdisplay = 1;
 
 // No emails.

--- a/tests/Fixture/example-config.php
+++ b/tests/Fixture/example-config.php
@@ -22,7 +22,7 @@ $CFG->admin    = 'admin';
 $CFG->directorypermissions = 02777;
 
 // Show debugging messages.
-$CFG->debug        = (E_ALL | E_STRICT);
+$CFG->debug        = PHP_VERSION_ID >= 80000 ? E_ALL : E_ALL | E_STRICT;
 $CFG->debugdisplay = 1;
 
 // No emails.


### PR DESCRIPTION
1. E_STRICT does not have any meaning since PHP 8.0 and is officially deprecated in PHP 8.4 (Addresses #344)
2. Add tests of moodle-plugin-ci on PHP 8.4