### PR TITLE
Support PHP 8.4; Add option --scss-deprecations for behat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.3'
+          - php: '8.4'
             moodle-branch: 'main'
             moodle-app: 'true'
           - php: '8.3'
@@ -202,7 +202,7 @@ jobs:
       matrix:
         include:
           # Each supported PHP version once. That's enough.
-          - php: '8.3'
+          - php: '8.4'
             moodle-branch: 'main'
             moodle-app: 'true'
           - php: '8.3'
@@ -294,6 +294,7 @@ jobs:
       matrix:
         include:
           # Each supported PHP version once. That's enough.
+          - php: '8.4'
           - php: '8.3'
           - php: '8.2'
           - php: '8.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
         moodle-plugin-ci phpdoc
         moodle-plugin-ci phpunit --verbose --coverage-text --fail-on-warning
         moodle-plugin-ci behat --profile default
-        moodle-plugin-ci behat --profile chrome
+        moodle-plugin-ci behat --profile chrome --scss-deprecations
         moodle-plugin-ci behat --profile firefox --tags="@local_ci&&~@app"
 
   buildphar:
@@ -279,7 +279,7 @@ jobs:
         php build/moodle-plugin-ci.phar phpdoc
         php build/moodle-plugin-ci.phar phpunit --verbose --coverage-text --fail-on-warning
         php build/moodle-plugin-ci.phar behat --profile default
-        php build/moodle-plugin-ci.phar behat --profile chrome
+        php build/moodle-plugin-ci.phar behat --profile chrome --scss-deprecations
         php build/moodle-plugin-ci.phar behat --profile firefox --tags="@local_ci&&~@app"
 
   selfupdatetest:

--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -3,11 +3,11 @@ language: php
 dist: focal
 
 addons:
-  postgresql: "13"
+  postgresql: "14"
   apt:
     packages:
-      - postgresql-13
-      - postgresql-client-13
+      - postgresql-14
+      - postgresql-client-14
       - libonig5
 
 services:
@@ -21,13 +21,13 @@ cache:
 
 php:
  - 7.4
- - 8.0
  - 8.1
+ - 8.3
 
 env:
  global:
-  - PGVER=13
-  - MOODLE_BRANCH=MOODLE_402_STABLE
+  - PGVER=14
+  - MOODLE_BRANCH=MOODLE_405_STABLE
   # Uncomment this to run Behat tests using the Moodle App.
   # - MOODLE_APP=true
  matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: php
 dist: focal
 
 addons:
-  postgresql: "13"
+  postgresql: "14"
   apt:
     packages:
-      - postgresql-13
-      - postgresql-client-13
+      - postgresql-14
+      - postgresql-client-14
       - libonig5
 
 services:
@@ -21,7 +21,7 @@ cache:
 
 env:
   global:
-    - PGVER=13
+    - PGVER=14
     - IGNORE_PATHS=ignore
     - IGNORE_NAMES=ignore_name.php
     - MUSTACHE_IGNORE_NAMES=broken.mustache

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
+## [Unreleased]
+### Added
+- Allow to run with PHP 8.4 (supported in Moodle 5.0)
+- New `--scss-deprecations` option added to the `behat` command
+
 ## [4.5.6] - 2025-01-31
 ### Fixed
 - Removed the PHPUnit --verbose option to comply with Moodle 5.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ### Added
 - Allow to run with PHP 8.4 (supported in Moodle 5.0)
 - New `--scss-deprecations` option added to the `behat` command
+- Updated travis.yml and the recommendations to run travis with Postgres 14
 
 ## [4.5.6] - 2025-01-31
 ### Fixed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -347,6 +347,16 @@ Print contents of Behat failure HTML files
 * Is negatable: no
 * Default: `false`
 
+#### `--scss-deprecations`
+
+Enable SCSS deprecation checks
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 #### `--help|-h`
 
 Display help for the given command. When no command is given display help for the list command

--- a/docs/TravisFileExplained.md
+++ b/docs/TravisFileExplained.md
@@ -16,11 +16,11 @@ dist: focal
 
 # Installs the updated version of PostgreSQL and extra APT packages.
 addons:
-  postgresql: "13"
+  postgresql: "14"
   apt:
     packages:
-      - postgresql-13
-      - postgresql-client-13
+      - postgresql-14
+      - postgresql-client-14
       - libonig5
 
 # Ensure DB and docker services are running.
@@ -40,7 +40,7 @@ cache:
 php:
  - 7.4
  - 8.0
- - 8.1
+ - 8.3
 
 # This section sets up the environment variables for the build.
 env:
@@ -49,9 +49,9 @@ env:
 # used, because, for PG 11 and up, both the user and the port were
 # changed by Travis. With that variable, the tool will switch to
 # socketed connections instead of localhost ones.
-  - PGVER=13
+  - PGVER=14
 # This line determines which version branch of Moodle to test against.
-  - MOODLE_BRANCH=MOODLE_402_STABLE
+  - MOODLE_BRANCH=MOODLE_405_STABLE
 # Uncomment this to run Behat tests using the Moodle App.
 #   - MOODLE_APP=true
 
@@ -78,9 +78,9 @@ env:
 #
 # jobs:
 #   include:
-#     - php: 8.0
-#       env: MOODLE_BRANCH=MOODLE_401_STABLE    DB=pgsql
-#     - php: 8.0
+#     - php: 8.3
+#       env: MOODLE_BRANCH=MOODLE_405_STABLE    DB=pgsql
+#     - php: 8.1
 #       env: MOODLE_BRANCH=MOODLE_400_STABLE    DB=pgsql
 #     - php: 7.4
 #       env: MOODLE_BRANCH=MOODLE_311_STABLE    DB=mysqli

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Behat features
         id: behat
         if: ${{ !cancelled() }}
-        run: moodle-plugin-ci behat --profile chrome
+        run: moodle-plugin-ci behat --profile chrome --scss-deprecations
 
       - name: Upload Behat Faildump
         if: ${{ failure() && steps.behat.outcome == 'failure' }}

--- a/res/template/config.php.txt
+++ b/res/template/config.php.txt
@@ -22,7 +22,7 @@ $CFG->admin    = 'admin';
 $CFG->directorypermissions = 02777;
 
 // Show debugging messages.
-$CFG->debug        = (E_ALL | E_STRICT);
+$CFG->debug        = PHP_VERSION_ID >= 80000 ? E_ALL : E_ALL | E_STRICT;
 $CFG->debugdisplay = 1;
 
 // No emails.

--- a/src/Command/BehatCommand.php
+++ b/src/Command/BehatCommand.php
@@ -48,6 +48,7 @@ class BehatCommand extends AbstractMoodleCommand
             ->addOption('auto-rerun', null, InputOption::VALUE_REQUIRED, 'Number of times to rerun failures', 2)
             ->addOption('selenium', null, InputOption::VALUE_REQUIRED, 'Selenium Docker image')
             ->addOption('dump', null, InputOption::VALUE_NONE, 'Print contents of Behat failure HTML files')
+            ->addOption('scss-deprecations', null, InputOption::VALUE_NONE, 'Enable SCSS deprecation checks')
             ->setDescription('Run Behat on a plugin');
     }
 
@@ -71,6 +72,16 @@ class BehatCommand extends AbstractMoodleCommand
         }
 
         $servers && $this->startServerProcesses($input);
+
+        if ($input->getOption('scss-deprecations')) {
+            $enableprocess = new Process([
+                'php', 'admin/tool/behat/cli/util_single_run.php',
+                '--enable',
+                '--add-core-features-to-theme',
+                '--scss-deprecations',
+            ], $this->moodle->directory, null, null, null);
+            $this->execute->passThroughProcess($enableprocess);
+        }
 
         $cmd = [
             'php', 'admin/tool/behat/cli/run.php',

--- a/tests/Command/BehatCommandTest.php
+++ b/tests/Command/BehatCommandTest.php
@@ -127,6 +127,13 @@ class BehatCommandTest extends MoodleTestCase
         $this->assertMatchesRegularExpression("/{$expectedName}/", $this->lastCmd);
     }
 
+    public function testExecuteWithScssDeprecations()
+    {
+        $commandTester = $this->executeCommand(null, null, ['--scss-deprecations' => true]);
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertMatchesRegularExpression('/--scss-deprecations/', $this->allCmds[0]);
+    }
+
     public function testExecuteNoFeatures()
     {
         $this->fs->remove($this->pluginDir . '/tests/behat');

--- a/tests/Fixture/example-config-with-chrome-capabilities.php
+++ b/tests/Fixture/example-config-with-chrome-capabilities.php
@@ -22,7 +22,7 @@ $CFG->admin    = 'admin';
 $CFG->directorypermissions = 02777;
 
 // Show debugging messages.
-$CFG->debug        = (E_ALL | E_STRICT);
+$CFG->debug        = PHP_VERSION_ID >= 80000 ? E_ALL : E_ALL | E_STRICT;
 $CFG->debugdisplay = 1;
 
 // No emails.

--- a/tests/Fixture/example-config-with-firefox-capabilities.php
+++ b/tests/Fixture/example-config-with-firefox-capabilities.php
@@ -22,7 +22,7 @@ $CFG->admin    = 'admin';
 $CFG->directorypermissions = 02777;
 
 // Show debugging messages.
-$CFG->debug        = (E_ALL | E_STRICT);
+$CFG->debug        = PHP_VERSION_ID >= 80000 ? E_ALL : E_ALL | E_STRICT;
 $CFG->debugdisplay = 1;
 
 // No emails.

--- a/tests/Fixture/example-config.php
+++ b/tests/Fixture/example-config.php
@@ -22,7 +22,7 @@ $CFG->admin    = 'admin';
 $CFG->directorypermissions = 02777;
 
 // Show debugging messages.
-$CFG->debug        = (E_ALL | E_STRICT);
+$CFG->debug        = PHP_VERSION_ID >= 80000 ? E_ALL : E_ALL | E_STRICT;
 $CFG->debugdisplay = 1;
 
 // No emails.


### PR DESCRIPTION
1. E_STRICT does not have any meaning since PHP 8.0 and is officially deprecated in PHP 8.4 (Addresses https://github.com/moodlehq/moodle-plugin-ci/issues/344)
2. Add tests of moodle-plugin-ci on PHP 8.4
3. Add option --scss-deprecations for behat (Addresses https://github.com/moodlehq/moodle-plugin-ci/issues/343)
4. Bump PHP and postgres versions in Travis (not related to these issues but it was already failing)