### PR TITLE
Prepare for 4.5.8 release

### DIFF
--- a/.travis.dist.yml
+++ b/.travis.dist.yml
@@ -1,3 +1,4 @@
+# Travis CI support has been deprecated in 4.5.8 and will be removed in 5.0.0. Please use GitHub Actions instead.
 language: php
 
 dist: focal

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Actions](https://docs.github.com/en/actions) or [Travis
 CI](https://travis-ci.com).  All of these tests and tools
 are run everytime a change is pushed to a GitHub branch or pull request.
 
+> [!WARNING]
+> Travis CI support has been deprecated in 4.5.8 and will be removed in 5.0.0.
+
 * [Getting started](https://moodlehq.github.io/moodle-plugin-ci/)
 * [Help topics](https://moodlehq.github.io/moodle-plugin-ci/Help.html)
 * [Changelog](https://moodlehq.github.io/moodle-plugin-ci/CHANGELOG.html)

--- a/bin/moodle-plugin-ci
+++ b/bin/moodle-plugin-ci
@@ -45,7 +45,7 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
 }
 
 // Current version. Keep it updated on releases.
-define('MOODLE_PLUGIN_CI_VERSION', '4.5.7');
+define('MOODLE_PLUGIN_CI_VERSION', '4.5.8');
 
 define('MOODLE_PLUGIN_CI_BOXED', '@is_boxed@');
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,11 +9,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+## [4.5.8] - 2025-07-08
 ### Changed
 - Bump default Selenium version to 4.
 
 ### Fixed
 - Add support for public directory structure in 5.1 (MDL-83424).
+
+### Deprecated
+- Using Travis CI has been deprecated in 4.5.8 and will be removed in 5.0.0. This includes removing configuration template and relevant documentation.
+- ACTION SUGGESTED: Consider using GitHub Actions for plugin CI testing.
 
 ## [4.5.7] - 2025-03-26
 ### Changed
@@ -766,7 +771,8 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 - `moodle-plugin-ci shifter` command.  Run YUI Shifter on plugin YUI modules.
 - `moodle-plugin-ci csslint` command.  Lints the CSS files in the plugin.
 
-[Unreleased]: https://github.com/moodlehq/moodle-plugin-ci/compare/4.5.7...main
+[Unreleased]: https://github.com/moodlehq/moodle-plugin-ci/compare/4.5.8...main
+[4.5.8]: https://github.com/moodlehq/moodle-plugin-ci/compare/4.5.7...4.5.8
 [4.5.7]: https://github.com/moodlehq/moodle-plugin-ci/compare/4.5.6...4.5.7
 [4.5.6]: https://github.com/moodlehq/moodle-plugin-ci/compare/4.5.5...4.5.6
 [4.5.5]: https://github.com/moodlehq/moodle-plugin-ci/compare/4.5.4...4.5.5

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ CI](https://travis-ci.com), if you are using
 `moodle-plugin-ci` with other CI services please do share your setup examples
 by creating a ticket.
 
+> [!WARNING]
+> Travis CI support has been deprecated in 4.5.8 and will be removed in 5.0.0.
+
 Why would you want to do this?  It saves you from having to remember to setup and run PHPUnit, Behat, code checker, etc
 every single time you make a change.  If you have enough test coverage, it also makes accepting pull requests painless
 because you can be more confident that the change wont break anything.  There are many more advantages to use CI


### PR DESCRIPTION
This includes Travis CI deprecation notes, effectively preparing for its removal in 5.0.0 (#351).

I am not sure if we need to output deprecation message in the tool, in theory is it possible to check Travis specific environment var, and echo message, I could not find any standard warning CI output format like GH has, would simple echo be noticed? It is also not supposed to break existing CI setup, only if users bump install to `^5` something _may_ stop working.

Any thoughts @stronk7 @andrewnicols ?

**Note for reviewer**: once approved, this needs to be merged without merge commit (use "Rebase and merge" option per [instruction](https://github.com/moodlehq/moodle-plugin-ci/blob/main/docs/ReleaseNewVersion.md).