### PR TITLE
docs: gha example should use postgres 16 and Moodle 4.5 LTS

### DIFF
--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4', '8.0', '8.1']
-        moodle-branch: ['MOODLE_401_STABLE']
+        moodle-branch: ['MOODLE_405_STABLE']
         database: [pgsql, mariadb]
 
     steps:

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.1', '8.2', '8.3']
         moodle-branch: ['MOODLE_405_STABLE']
         database: [pgsql, mariadb]
 


### PR DESCRIPTION
As Moodle main/5.2 requires postgres:16 and Moodle 4.5 is the current LTS, bump both values in the sample GitHub Action file.