### PR TITLE
Add GitLab CI example for prebuilt Docker image

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- GitLab CI/CD example using a prebuilt Docker image.
 
 ## [4.5.10] - 2026-02-09
 ### Changed

--- a/docs/GitLabCI.md
+++ b/docs/GitLabCI.md
@@ -1,0 +1,105 @@
+---
+layout: page
+title: GitLab CI example
+---
+
+This page shows a starting point for running `moodle-plugin-ci` in GitLab
+CI/CD with a prebuilt Docker image. It is useful when a plugin project wants a
+shorter pipeline setup than installing PHP, Composer, Node.js, database clients
+and `moodle-plugin-ci` during every job.
+
+The example uses the community-maintained
+[`ffhs/moodle-lms-plugin-ci`](https://github.com/ffhs/moodle-lms-plugin-ci)
+image published on
+[Docker Hub](https://hub.docker.com/r/ffhs/moodle-lms-plugin-ci). Review the
+image, tags and release policy before adopting it in a production pipeline. For
+stricter supply-chain controls, mirror the image into your own registry and pin
+by digest.
+
+## Example `.gitlab-ci.yml`
+
+```yaml
+stages:
+  - test
+
+variables:
+  COMPOSER_ALLOW_SUPERUSER: "1"
+  COMPOSER_CACHE_DIR: "$CI_PROJECT_DIR/.cache/composer"
+  NPM_CONFIG_CACHE: "$CI_PROJECT_DIR/.cache/npm"
+  CI_BUILD_DIR: "/tmp/moodle-plugin"
+  MOODLE_BRANCH: "MOODLE_500_STABLE"
+
+.moodle_plugin_ci:
+  stage: test
+  interruptible: true
+  image: "ffhs/moodle-lms-plugin-ci:${PHP_VERSION}"
+  parallel:
+    matrix:
+      - PHP_VERSION: ["8.2", "8.3", "8.4"]
+  cache:
+    key: "moodle-plugin-ci"
+    paths:
+      - .cache/composer/
+      - .cache/npm/
+    policy: pull-push
+  before_script:
+    - mkdir -p "$CI_BUILD_DIR"
+    - cp -a "$CI_PROJECT_DIR/." "$CI_BUILD_DIR/"
+    - moodle-plugin-ci install
+  script:
+    - moodle-plugin-ci phplint
+    - moodle-plugin-ci phpmd
+    - moodle-plugin-ci phpcs --max-warnings 0
+    - moodle-plugin-ci phpdoc --max-warnings 0
+    - moodle-plugin-ci validate
+    - moodle-plugin-ci savepoints
+    - moodle-plugin-ci mustache
+    - moodle-plugin-ci grunt --max-lint-warnings 0
+    - moodle-plugin-ci phpunit --fail-on-warning
+
+mariadb:
+  extends: .moodle_plugin_ci
+  services:
+    - name: mariadb:10
+      alias: mariadb
+      variables:
+        MYSQL_USER: "root"
+        MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+        MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+  variables:
+    DB: "mariadb"
+    DB_HOST: "mariadb"
+
+postgres:
+  extends: .moodle_plugin_ci
+  services:
+    - name: postgres:15
+      alias: pgsql
+      variables:
+        POSTGRES_USER: "postgres"
+        POSTGRES_HOST_AUTH_METHOD: "trust"
+  variables:
+    DB: "pgsql"
+    DB_HOST: "pgsql"
+```
+
+## Adapting the example
+
+Adjust `MOODLE_BRANCH` and `PHP_VERSION` to match the Moodle versions supported
+by your plugin. If your plugin has no PHPUnit coverage yet, keep the validation
+steps and remove `moodle-plugin-ci phpunit --fail-on-warning` until tests are
+available.
+
+Projects that use Behat need an additional browser service, a web server
+process and the relevant `MOODLE_BEHAT_*` environment variables. See the
+`moodle-plugin-ci behat` options in [CLI commands and options](CLI.md) before
+adding Behat to the GitLab pipeline.
+
+If the default command set is enough for your project, the `script` section can
+be shortened to:
+
+```yaml
+script:
+  - moodle-plugin-ci parallel
+```

--- a/docs/Help.md
+++ b/docs/Help.md
@@ -10,6 +10,7 @@ Always a good idea to check the [change log](CHANGELOG.md) if something suddenly
 ## Help topics
 
 * [GitHub Actions workflow file explained](GHAFileExplained.md): every line of the `gha.dist.yml` file explained.
+* [GitLab CI example](GitLabCI.md): a GitLab CI/CD starting point using a prebuilt Docker image.
 * [Travis CI file explained](TravisFileExplained.md): every line of the `.travis.dist.yml` file explained.
 * [Add extra Moodle configs](AddExtraConfig.md): how to add extra configs to Moodle `config.php`.
 * [Add extra plugins](AddExtraPlugins.md): how to add plugin dependencies to Moodle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,8 @@ and tools are run everytime a change is pushed to a GitHub branch or pull
 request.
 
 We currently provide user manual how to use it with [GitHub
-Actions](https://docs.github.com/en/actions) and [Travis
+Actions](https://docs.github.com/en/actions), [GitLab
+CI/CD](https://docs.gitlab.com/ee/ci/) and [Travis
 CI](https://travis-ci.com), if you are using
 `moodle-plugin-ci` with other CI services please do share your setup examples
 by creating a ticket.
@@ -67,6 +68,13 @@ name, click Actions tab and see your build status.  You may find this [Quick
 Start manual](https://docs.github.com/en/actions/quickstart#viewing-your-workflow-results)
 useful. Now whenever you push commits to your plugin repo or it gets a new
 pull request, GitHub will run a build to make sure nothing broke.
+
+### GitLab CI/CD
+
+Copy the example `.gitlab-ci.yml` from the [GitLab CI example](GitLabCI.md)
+page into the root of your plugin repository. Review the Moodle branch, PHP
+versions and database jobs, then commit and push the file to GitLab to trigger a
+pipeline.
 
 ### Travis CI
 


### PR DESCRIPTION
## Summary
- add a GitLab CI/CD example for running moodle-plugin-ci with the community-maintained prebuilt Docker image
- link the new page from the help and introduction docs
- document database service setup, cache paths, common validation commands, and production image pinning guidance

## Rationale
Issue #383 requested an example setup for GitLab CI using the prebuilt Docker image. This gives Moodle plugin maintainers a copyable starting point outside GitHub Actions and Travis CI.

## Validation
- ran `git diff --check`
- reviewed the example against the current command and environment-variable conventions in the repository
- full `make validate` was not run locally because PHP and Composer are not available on this Windows environment

Addresses #383.