### PR TITLE
gha: security, performance, efficiency modernization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,21 @@ on:
   push:
     tags: [ '*' ]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     # Avoid forks to perform this job.
     if: github.repository_owner == 'moodlehq'
     name: Create Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup PHP 8.1
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,19 @@ name: Moodle Plugin CI
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   selftest:
     name: CI test (make validate)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup PHP 7.4
       uses: shivammathur/setup-php@v2
@@ -28,11 +33,13 @@ jobs:
   coverage:
     if: github.repository == 'moodlehq/moodle-plugin-ci'
     name: Code coverage (codecov)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup PHP 7.4
       uses: shivammathur/setup-php@v2
@@ -58,7 +65,7 @@ jobs:
   citest:
     name: Integration tests
     needs: selftest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
@@ -108,14 +115,16 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup PHP ${{ matrix.php }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
         extensions: pgsql, zip, gd, xmlrpc, soap
-        ini-values: max_input_vars=5000
+        ini-values: max_input_vars=5000, opcache.enable_cli=1, opcache.jit = disable
         # We want to verify that xdebug works for coverage. Once we only support
         # Moodle 3.10/PHPUnit 8 and up, we can switch our tests to pcov too.
         coverage: xdebug
@@ -164,11 +173,13 @@ jobs:
   buildphar:
     name: Build moodle-plugin-ci.phar
     needs: selftest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup PHP 8.1
       uses: shivammathur/setup-php@v2
@@ -182,7 +193,7 @@ jobs:
         php build/moodle-plugin-ci.phar list
 
     - name: Upload PHAR artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: moodle-plugin-ci.phar
         path: build/moodle-plugin-ci.phar
@@ -190,7 +201,7 @@ jobs:
   phartest:
     name: Integration tests (PHAR)
     needs: buildphar
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
@@ -237,14 +248,16 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup PHP ${{ matrix.php }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
         extensions: pgsql, zip, gd, xmlrpc, soap
-        ini-values: max_input_vars=5000
+        ini-values: max_input_vars=5000, opcache.enable_cli=1, opcache.jit = disable
         coverage: pcov
 
     - name: Initialise moodle-plugin-ci
@@ -260,7 +273,7 @@ jobs:
         echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
 
     - name: Download PHAR artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: moodle-plugin-ci.phar
         path: build
@@ -297,7 +310,7 @@ jobs:
   selfupdatetest:
     name: SelfUpdate tests (PHAR)
     needs: buildphar
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       lowest_release: '4.1.8'
 
@@ -319,11 +332,11 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         extensions: pgsql, zip, gd, xmlrpc, soap
-        ini-values: max_input_vars=5000
+        ini-values: max_input_vars=5000, opcache.enable_cli=1
         coverage: none
 
     - name: Download base ${{ env.lowest_release }} PHAR artifact
-      uses: robinraju/release-downloader@v1.10
+      uses: robinraju/release-downloader@v1.13
       with:
         repository: moodlehq/moodle-plugin-ci
         tag: ${{ env.lowest_release }}

--- a/gha.dist.yml
+++ b/gha.dist.yml
@@ -2,13 +2,16 @@ name: Moodle Plugin CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
-        image: postgres:16
+        image: ${{ matrix.database == 'pgsql' && 'postgres:16' || '' }}
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -17,7 +20,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
       mariadb:
-        image: mariadb:10
+        image: ${{ matrix.database == 'mariadb' && 'mariadb:10' || '' }}
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -36,16 +39,17 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: plugin
+          persist-credentials: false
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
-          ini-values: max_input_vars=5000
+          ini-values: max_input_vars=5000, opcache.enable_cli=1
           # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
           # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
           coverage: none
@@ -110,7 +114,7 @@ jobs:
 
       - name: Upload Behat Faildump
         if: ${{ failure() && steps.behat.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Behat Faildump (${{ join(matrix.*, ', ') }})
           path: ${{ github.workspace }}/moodledata/behat_dump


### PR DESCRIPTION
Changes:

- Minimize permissions and do not persist credentials (inspired by [zizmorcore/zizmor](https://github.com/zizmorcore/zizmor))
- Only initialize necessary database images (inspired by Moodle core workflows)
- Set php INI value: opcache.enable_cli=1 (noticeably saves installation time and thus CI minutes/money)
- Use current, recommended GitHub action versions
- Use `ubuntu-24.04`, because `ubuntu-22.04` is on track for removal in 8 months

I understand that some of these changes might be too radical for the current major release. Please feel free to either divide the changes as you desire or ask me to. Thank you so much for support this amazing tool and this amazing community.