### PR TITLE
Fix Moodle App Behat CI (pin Chrome 145.0, drop App on Moodle 4.1) + bump GitHub Actions

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -12,4 +12,4 @@ jobs:
     name: Auto assign PR
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v2.1.0
+      - uses: toshimaru/auto-author-assign@v3.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP 8.1
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,8 @@ jobs:
             moodle-app: 'true'
           - php: '8.1'
             moodle-branch: 'MOODLE_401_STABLE'
-            moodle-app: 'true'
+            # No Moodle App: the latest moodleappbehat plugin requires
+            # core_external\util, which only exists in Moodle 4.2 and up.
           - php: '8.0'
             moodle-branch: 'MOODLE_400_STABLE'
           - php: '8.0'
@@ -231,7 +232,8 @@ jobs:
             moodle-app: 'true'
           - php: '8.0'
             moodle-branch: 'MOODLE_401_STABLE'
-            moodle-app: 'true'
+            # No Moodle App: the latest moodleappbehat plugin requires
+            # core_external\util, which only exists in Moodle 4.2 and up.
           - php: '7.4'
             moodle-branch: 'MOODLE_400_STABLE'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup PHP 7.4
       uses: shivammathur/setup-php@v2
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup PHP 7.4
       uses: shivammathur/setup-php@v2
@@ -49,7 +49,7 @@ jobs:
       run: make coverage-phpunit
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./build/logs/clover.xml
@@ -108,7 +108,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup PHP ${{ matrix.php }}
       uses: shivammathur/setup-php@v2
@@ -168,7 +168,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup PHP 8.1
       uses: shivammathur/setup-php@v2
@@ -182,7 +182,7 @@ jobs:
         php build/moodle-plugin-ci.phar list
 
     - name: Upload PHAR artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: moodle-plugin-ci.phar
         path: build/moodle-plugin-ci.phar
@@ -237,7 +237,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup PHP ${{ matrix.php }}
       uses: shivammathur/setup-php@v2
@@ -260,7 +260,7 @@ jobs:
         echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
 
     - name: Download PHAR artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: moodle-plugin-ci.phar
         path: build
@@ -323,7 +323,7 @@ jobs:
         coverage: none
 
     - name: Download base ${{ env.lowest_release }} PHAR artifact
-      uses: robinraju/release-downloader@v1.10
+      uses: robinraju/release-downloader@v1.13
       with:
         repository: moodlehq/moodle-plugin-ci
         tag: ${{ env.lowest_release }}

--- a/src/Command/BehatCommand.php
+++ b/src/Command/BehatCommand.php
@@ -226,7 +226,14 @@ class BehatCommand extends AbstractMoodleCommand
         }
 
         if ($profile === 'chrome') {
-            return 'selenium/standalone-chrome:4';
+            // Pin Chrome to the 145.0 line: the rolling ":4" tag now resolves to Chrome 147+,
+            // which breaks the Moodle App Behat tests ("Moodle App not launched properly").
+            // Selenium itself recommends pinning a browser version rather than using a rolling
+            // tag such as "latest"/":4". See the Selenium tagging convention:
+            // https://github.com/SeleniumHQ/docker-selenium/wiki/Tagging-Convention
+            // Still overridable via the --selenium option or the MOODLE_BEHAT_SELENIUM_IMAGE env var.
+            // See https://github.com/moodlehq/moodle-plugin-ci/issues/385
+            return 'selenium/standalone-chrome:145.0';
         }
 
         if ($this->usesLegacyPhpWebdriver()) {

--- a/tests/Command/BehatCommandTest.php
+++ b/tests/Command/BehatCommandTest.php
@@ -94,7 +94,7 @@ class BehatCommandTest extends MoodleTestCase
 
         $commandTester = $this->executeCommand(null, null, ['--start-servers' => true, '--profile' => 'chrome']);
         $this->assertSame(0, $commandTester->getStatusCode());
-        $this->assertMatchesRegularExpression('/selenium\/standalone-chrome:4/', $this->allCmds[1]);
+        $this->assertMatchesRegularExpression('/selenium\/standalone-chrome:145.0/', $this->allCmds[1]);
     }
 
     public function testExecuteWithFirefoxProfile()


### PR DESCRIPTION
## Problem

All `moodle-app: true` integration jobs (and their PHAR equivalents) currently fail. The Behat step `moodle-plugin-ci behat --profile default` aborts with:

```
Behat\Mink\Exception\DriverException: Moodle App not launched properly
  in moodle/local/moodleappbehat/tests/behat/behat_app_helper.php:264
```

This reproduces on `main` here as well (e.g. run [26920794145](https://github.com/moodlehq/moodle-plugin-ci/actions/runs/26920794145)).

## Root cause & fixes

### 1. Chrome 148 breaks the Moodle App → pin Chrome to `145.0`
When `MOODLE_APP=true`, the `default`/`chrome` Behat profile starts Selenium from the rolling tag `selenium/standalone-chrome:4`, which now resolves to **Chrome 148** (identical digest to `selenium/standalone-chrome:148.0`). Chrome 148 is incompatible with the currently released Moodle App: the app loads but its login screen never renders, so Behat reports "Moodle App not launched properly".

Pin the Chrome image to the `145.0` line — the latest browser build the released App supports, still receiving patch updates within that version. This follows Selenium's own [tagging convention](https://github.com/SeleniumHQ/docker-selenium/wiki/Tagging-Convention):

> The example above uses `latest` as a tag, but we recommend to full tag to pin a specific browser and Grid version. Please see Tagging Conventions.

Only Chrome is pinned (Firefox untouched), and it stays overridable via the `--selenium` option or the `MOODLE_BEHAT_SELENIUM_IMAGE` environment variable. The unit test is updated accordingly. Refs #385.

### 2. Moodle 4.1 incompatible with the latest App Behat plugin → drop App on 4.1
With Chrome fixed, Moodle 4.1 surfaces a second, pre-existing failure:

```
Fatal error: Class "core_external\util" not found
  in local/moodleappbehat/tests/behat/behat_app_helper.php:418
```

The latest `moodle-local_moodleappbehat` plugin uses `core_external\util`, introduced in **Moodle 4.2**. Moodle 4.1 only has the old `external_util`, so the App tests cannot run there. `moodle-app` is removed from the two `MOODLE_401_STABLE` matrix entries (citest and phartest) — 4.1 is still fully tested otherwise, and the `@app` scenario is skipped when the App is not configured (as already happens for Moodle 4.0 and earlier).

### 3. Bump GitHub Actions to latest (fix Node.js 20 deprecation warning)

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `codecov/codecov-action` | v4 | v7 |
| `robinraju/release-downloader` | v1.10 | v1.13 |
| `toshimaru/auto-author-assign` | v2.1.0 | v3.0.2 |

`shivammathur/setup-php` stays on `v2` (latest major).

## Testing

- `vendor/bin/phpunit --filter BehatCommandTest` → OK; `php-cs-fixer` → 0 violations.
- Full CI is **green** on all jobs (citest + phartest, Moodle 3.9 → 5.1 / main), including every App job from Moodle 4.2 upward. Validated here: [ateeducacion run 27329029179](https://github.com/ateeducacion/moodle-plugin-ci/actions/runs/27329029179).
